### PR TITLE
Add manager level guidance for understanding coding QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This document forms part of the Quality Guidance, published by the Quality and I
 We welcome all constructive feedback and contributions.
 
 To provide feedback or request new content, you can [create an issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) on this book's repository.
-Alternatively, you can always drop us an [email](gsshelp@statistics.gov.uk).
+Alternatively, you can always drop us an [email](mailto:Analysis.Function@ons.gov.uk).
 
 If you'd like to contribute, please also [create or comment on an issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) to describe the changes that you'd like to make.
 This will allow discussion around whether content is suitable for this book, before you put the hard work into implementing it.

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -14,7 +14,7 @@ html:
   use_repository_button: true
   use_issues_button: true
   use_edit_page_button: true
-  extra_footer: "<p>Best Practice & Impact division, Office for National Statistics</p><p>This document is very young, please help use to make it grow by providing any feedback by <a href='mailto:gsshelp@statistics.gov.uk'>email</a> or via the <a href='https://github.com/best-practice-and-impact/qa-of-code-guidance'>GitHub repository</a>."
+  extra_footer: "<p>Analysis Function reproducible analytical pipelines (RAP) support</p><p>This is a living document, please help use to make it grow by providing any feedback <a href='mailto:Analysis.Function@ons.gov.uk'>by email</a> or via the <a href='https://github.com/best-practice-and-impact/qa-of-code-guidance'>GitHub repository</a>."
   extra_navbar: "<p>Book version 2022.2</p><a href='https://www.gov.uk/government/organisations/government-analysis-function' target='_blank'><img src='./_static/af_logo.png' alt='The Government Analysis Function logo' style='width:50%;'></a>"
 
 sphinx:

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -7,6 +7,7 @@
       - file: checklist_lower
       - file: checklist_moderate
       - file: checklist_higher
+  - file: managers_guide
 
 - part: Guidance
   chapters:

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -3,12 +3,13 @@ root: intro
 parts:
 - caption: Overview
   chapters:
+  - file: managers_guide
   - file: checklists
     sections:
     - file: checklist_lower
     - file: checklist_moderate
     - file: checklist_higher
-  - file: managers_guide
+
 
 - caption: Guidance
   chapters:

--- a/book/checklists.md
+++ b/book/checklists.md
@@ -1,12 +1,8 @@
 # Code quality assurance checklists
 
-```{note}
-This section is an early draft. Please get in touch with feedback [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or via [gsshelp@statistics.gov.uk](mailto:gsshelp@statistics.gov.uk).
-```
-
 This sections aims to provide a checklist for quality assurance of analytical projects in government.
 
-As per the [Aqua book](https://www.gov.uk/government/publications/the-aqua-book-guidance-on-producing-quality-analysis-for-government), quality assurance should be proportional to the risk and complexity of your analysis. With this in mind, we have provided checklists for three levels of quality assurance.
+As per the [Aqua book](https://www.gov.uk/government/publications/the-aqua-book-guidance-on-producing-quality-analysis-for-government), quality assurance should be proportional to the complexity and risk of your analysis. With this in mind, we have provided checklists for three levels of quality assurance.
 
 We recommend that you consider the risk and complexity associated with your project. Given this assessment, you should select and tailor the checklists that we have provided. The values and risk tolerance varies between government departments, so it is important that these are considered when deciding what quality assurance is adequate. You may choose to select elements from each level of quality assurance to address the specific risks associated with your work.
 

--- a/book/data.md
+++ b/book/data.md
@@ -12,6 +12,8 @@ This requires suitable storage of data, with documentation and versioning of the
 :class: admonition-strategies
 
 [The Government Data Quality Framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework) focuses primarily on assessing and improving the quality of input data. It should be a primary resource for all analysts working with data in the public sector.
+
+The Office for Statistics Regulation provides a standard for [quality assurance of administrative data](https://osr.statisticsauthority.gov.uk/guidance/administrative-data-and-official-statistics/).
 ```
 
 ## Data storage
@@ -196,21 +198,13 @@ This might be documented in analysis reports or automatically logged by your cod
 
 ## Releasing data
 
-```{todo}
-Open Linked Data ratings
+You should use the [5-star open data standards](https://5stardata.info/en/) to understand and improve the current utility of your published data. The [CSV on the Web (CSVW) standard](https://csvw.org/) is recommended for achieving the highest ratings of open data.
 
-Use CSVW when possible
+When publishing statistics you should follow government guidance for [releasing statistics in spreadsheets](https://gss.civilservice.gov.uk/policy-store/releasing-statistics-in-spreadsheets/).
 
-[#23](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues/23)
-```
+When publishing or sharing tabular data, you should follow the [GOV.UK Tabular data standard](https://www.gov.uk/government/publications/recommended-open-standards-for-government/tabular-data-standard).
 
-
-Other guidance addresses:
-* [Releasing statistics in spreadsheets](https://gss.civilservice.gov.uk/policy-store/releasing-statistics-in-spreadsheets/)
-* [Quality assurance of administrative data](https://osr.statisticsauthority.gov.uk/guidance/administrative-data-and-official-statistics/)
-* [Data linking methods](https://www.gov.uk/government/publications/joined-up-data-in-government-the-future-of-data-linking-methods)
-* When publishing or sharing tabular data, you should follow the [GOV.UK Tabular data standard](https://www.gov.uk/government/publications/recommended-open-standards-for-government/tabular-data-standard).
-
-Analysts producing published statistics may also be interested in [Connected Open Government Statistics (COGS)](https://gss.civilservice.gov.uk/guidance/the-gss-data-project/).
+Analysts producing published statistics may also be interested in [Connected Open Government Statistics (COGS)](https://gss.civilservice.gov.uk/guidance/the-gss-data-project/) and [the review of government data linking methods](https://www.gov.uk/government/publications/joined-up-data-in-government-the-future-of-data-linking-methods)
+.
 
 Guidance from the UK Data Service describes [data security considerations](https://www.ukdataservice.ac.uk/manage-data/store/security).

--- a/book/intro.md
+++ b/book/intro.md
@@ -53,7 +53,7 @@ For keyboard navigation, {kbd}`Up Arrow` and {kbd}`Down Arrow`keys can be used t
 
 ### Feedback and reporting accessibility problems
 
-We’re always looking to improve the accessibility of our guidance. If you find any problems not listed on this page or think that we’re not meeting accessibility requirements, please contact us by emailing [gsshelp@statistics.gov.uk](mailto:gsshelp@statistics.gov.uk). Please also get in touch if you are unable to access any part of this guidance, or require the content in a different format.
+We’re always looking to improve the accessibility of our guidance. If you find any problems not listed on this page or think that we’re not meeting accessibility requirements, please contact us by emailing [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk). Please also get in touch if you are unable to access any part of this guidance, or require the content in a different format.
 
 We will consider your request and aim to get back to you within five working days.
 

--- a/book/learning.md
+++ b/book/learning.md
@@ -78,7 +78,7 @@ Please note that learning resources from non-government training providers (i.e.
 
 ## Reproducible Analytical Pipelines
 
-* [GSS RAP Overview](https://gss.civilservice.gov.uk/reproducible-analytical-pipelines/)
-* [RAP Champion Network](https://gss.civilservice.gov.uk/about-us/champion-networks/reproducible-analytical-pipeline-rap-champions/#more-information-about-rap-champions)
+* [GSS RAP Overview](https://analysisfunction.civilservice.gov.uk/support/reproducible-analytical-pipelines/)
+* [The cross government RAP Champion Network](https://analysisfunction.civilservice.gov.uk/support/reproducible-analytical-pipelines/reproducible-analytical-pipeline-rap-champions/)
 * [ONS Data Science Campus RAP learning materials](https://github.com/datasciencecampus/gov-uk-rap-materials)
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,7 +1,9 @@
 # Managing analytical code development
 
 ```{note}
-This section is a working draft. Please get in touch with feedback [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or via [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk).
+This section is a working draft.
+
+Please get in touch with feedback or case studies to support the guidance [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or via [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk).
 ```
 
 This section of the guidance is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,90 +1,102 @@
 # Managers guide
 
-This section is aimed at those who manage analysts in government or act as product owners for analytical code.
+This section is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 
-Learning from previous projects, we've found that successful reproducible analytical pipeline (RAP) projects require: 
+Learning from previous projects, we've found that successfully developing analytical code requires: 
 * Intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
 * Committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
 * Motivation for the project and personal development from those working on the project. 
 * Having appropriate tools available for the development and deployment of the project. 
 * A plan for requirement collection and transitioning the product into business as usual. 
 
-It is common for RAP transformation to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
+It is common for process transformation to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
 
 Analytical managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
 
-## Questions around quality assurance
+[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing your analysis.
+
+The rest of this page describes how you can ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices are refered to as reproducible analytical pipelines (RAP).
+
+## Analysis as code is beneficial
+
+Carrying out analysis as code has many benefits:
+* Reproducible, quality analysis
+* Greater efficiency and timeliness, through automation.
+* Transparent analysis and quality assurance, increasing trust.
+* Improved business continuity and knowledge management.
+
+Achieving all of these benefits and mitigating risks associated with analysis requires adequate quality assurance.
+
+## Analytical code requires quality assurance
 
 We recommend that you ask your team the following questions to understand the quality assurance that is being applied in their analysis. Good quality assurance should be applied throughout an analysis project, therefore, it is important that the areas outlined below are reviewed regularly.
 
-The practices outlined below should be applied proportionately to the business risk and complexity of the project. You should aim to establish what adequate quality assurance looks like at the beginning of a project. These questions can then be used throughout the project to assess whether this goal is being met.
+The practices outlined below should be applied proportionately to the business risk and complexity of the project. Analytical code that doesn't apply these practices carries similar risk to other analysis appraoches. You should aim to establish what adequate quality assurance looks like early on in a project. These questions can then be used throughout the project to assess whether this goal is being met, or that the team are moving towards this goal.
 
 ### Why have your chosen to do things this way?
 
 * The methodology and data should be suitable for the question being asked.
-* The analysis tools that your team use should have some rationale for being chosen.
-* Users should be consulted throughout the development process.
-* The program should be maintainable if it will be re-used.
+* Your team should be using open-source analysis tools, with a reason for each given tool being chosen.
+* Users should be consulted throughout the development process, to ensure that their need is being met.
 
 ### What happens when the analysis fails to run?
 
 * When code fails to run, it should provide informative error messages to describe the problem.
+* If another team will operate the code, error messages should help users to correct the problem.
 * Errors or warnings might also be raised when data validation is not met.
+
+### How is your code structured?
+
+* Logic should be written as functions, so that it can be reused consistently and tested.
+* The code that executes the analysis should be very readable.
+* Similar functions should be grouped together in separate files, so that it is easy to identify them.
 
 ### How easy is it to adjust the way that the analysis runs?
 
-* Configuration of the code that might change should be easily identified from the code.
-* Ideally separate configuration files are used to store these options.
-
+* Parts of the code that may change should be stored in separate configuration files, so that they can be changed without changing the code.
+* Things that often change in analysis code include input and output file paths, reference dates and model parameters.
 ### How are you storing input data?
 
 * Input data should be versioned, so that analysis outputs can be reproduced.
-* Data should be stored in an open format (e.g. CSV and ODS), not formats that are restricted to proprietary software like SAS and Stata. 
+* Data should be stored in an open format (e.g. CSV or ODS), not formats that are restricted to proprietary software like SAS and Stata. 
 * Large or complex datasets should be stored in a database.
-
-### How have you specified the analysis?
-
-* The code should have an accompanying specification.
-* The specification should show how data are transferred from function to function.
-* The specification helps reviewers to understand the code. Well-specified code is easier to understand and maintain.
 
 ### What does the documentation look like?
 
-* Every function should be documented.
-* Function documentation should say what goes in and what comes out of each function.
-* Documentation should be easy to read, accessible, and stored closely to the code.
-* Good documentation includes usage examples and test data.
+* Every function should be documented in the code, so that it is clear what the function is supposed to do.
+* Function documentation should also include what goes in and what comes out of each function.
+* Where code will be run or re-used by others, documentation should include usage examples and test data.
 
 ### How has peer review been done?
 
 * Skilled colleagues should conduct internal peer reviews of the code.
+* Peer review should ideally be carried out on individual changes to the code, rather than the final analysis.
 * If the product is high risk, an external peer review should also be conducted.
-* Peer review should follow a standard procedure.
+* Peer review should follow a standard procedure, so that reviews are consistent.
 
-### How have you kept track of who made changes and for which reasons?
+### How have you kept track of who made changes to the code and why?
 
 * The code, documentation, and peer review should all be version controlled. Git software is most commonly used for this.
 * There should be a clear record of every change and who made it.
-* Each change should have a reason.
+* Each change should be linked to a reason, for example, a new requirement or a bug in the existing code.
 * Reviews should be stored with the version of the analysis that was reviewed.
 
 ### How have you tested the code?
 
 * Testing means making sure that the code produces the right outputs for realistic example input data.
-* Good testing is automated 'unit' testing.
+* Automated 'unit' testing should be applied, to ensure that code continues to work after future changes to the code.
 * Each function and the end-to-end analysis should be tested using minimal, realistic data.
 
 ### What have you tested?
 
-* Aim for every single function being tested
-* Tests should account for edge cases like missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs.
-* Reviewers should sign-off that there is enough testing.
+* Aim for every single function being tested.
+* Tests should account for realistic cases, which might include missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs.
+* Reviewers should sign-off that there is enough testing to assure that the code is working as expected.
 
 ### What are the dependencies?
 
+* Documenting the code dependencies allows others to reproduce the analysis more easily.
 * Dependencies include anything the code needs to run, including software and package versions.
-* It can be difficult to run code on other systems when dependencies are not documented.
-* Documenting dependencies allows others to reproduce the analysis more easily.
 
 ### How can we further improve the quality of the code?
 
@@ -93,14 +105,14 @@ The practices outlined below should be applied proportionately to the business r
 
 ### Which other systems have you run this on?
 
-* Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this. 
+* Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this.
 * Container systems, like Docker, help to create reproducible environments to run code.
 
 ### How would we do a dual run?
 
 * For the highest risk analysis, the results of your analysis should be compared from two independent calculations (i.e. one from another tool or software).
 * Where possible, outputs should be compared between analysis using a variety of realistic inputs.
-* You may also wish to parallel run the new analysis system with a legacy approach, to quantify changes or improvements to the analysis.
+* You may also wish to parallel run new analysis processes with a legacy approach, to quantify changes or improvements to the analysis.
 
 # Other resources
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -15,7 +15,7 @@ It is common for this kind of transformation to identify quality issues in the c
 
 The rest of this page describes the benefits of doing analysis as code and aims to help you ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices are refered to as reproducible analytical pipelines (RAP).
 
-Analysis team managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
+Analysis team managers should not need an in-depth understanding of the code produced by their team. However, they should be confident that the approach the team has taken is appropriate given the user need, and that proportionate quality assurance is being applied to the development and running of the analysis.
 
 ## Analysis as code is beneficial
 
@@ -36,7 +36,7 @@ The practices outlined below should be applied proportionately to the business r
 ### Why have your chosen to do things this way?
 
 * The methodology and data should be suitable for the question being asked.
-* Your team should be using open-source analysis tools, with a reason for each given tool being chosen.
+* Your team should be using open-source analysis tools. They should be able to explain why they have chosen these tools and why they are confident that they are appropriate and fit for purpose.
 * Users should be consulted throughout the development process, to ensure that their need is being met.
 
 ### How is your code structured?
@@ -67,6 +67,7 @@ The practices outlined below should be applied proportionately to the business r
 * Peer review of individual changes to the code will help to identify issues sooner. This is also more manageable than reviewing the complete final analysis.
 * If the product is high risk, an external peer review should also be conducted.
 * Peer review should follow a standard procedure, so that reviews are consistent.
+* There should be evidence that peer reviews are acted on. When issues or concerns are raised, they should be addressed before the analysis is used.
 
 ### How have you kept track of who made changes to the code and why?
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,5 +1,9 @@
 # Managing analytical code development
 
+```{note}
+This section is a working draft. Please get in touch with feedback [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or via [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk).
+```
+
 This section of the guidance is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 
 It aims to help you support your team to apply the good quality assurance practices described in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Processes that apply these good practices are referred to as a reproducible analytical pipelines (RAP).

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -108,7 +108,7 @@ These questions can be used throughout the development of the analysis, to asses
 [Project documentation](project_documentation.md) ensures that others can reproduce our analysis.
 
 * User instructions should be provided for running the analysis.
-* Software and package versions should be documented with the code. Typically package versions are recorded using `setup.py` and `requirements.txt` files (Python) or `DESCRIPTION` file (R).
+* Software and package versions should be documented with the code. Typically package versions are recorded using `setup.py` and `requirements.txt` files (Python) or a `DESCRIPTION` file (R).
 * Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this.
 * When the same analysis is run multiple times or on different systems it should give reproducible outcomes.
 * Container systems, like Docker, help to create reproducible environments to run code.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -111,7 +111,7 @@ The practices outlined below should be applied proportionately to the business r
 
 ### How would we do a dual run?
 
-* For the highest risk analysis, the results of your analysis should be compared from two independent calculations (i.e. one from another tool or software).
+* For high risk parts of the analysis, the results of this part of the analysis should be compared from two independent calculations (i.e. one from another tool or software).
 * Where possible, outputs should be compared between analysis using a variety of realistic inputs.
 * You may also wish to parallel run new analysis processes with a legacy approach, to quantify changes or improvements to the analysis.
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -34,7 +34,9 @@ While quality assurance must be applied relative to the risk and complexity of t
 Note that it is important to maintain technical skills in the analysis team for sustainability, to ensure that the analysis can be understood, updated and maintained.
 ```
 
-Despite the initial cost of developing technical skills, [evidence shows that applying good practices increases the efficiency of code development and maintainability of the code](https://www.devops-research.com/research.html). Not following good practices creates [technical debt](https://en.wikipedia.org/wiki/Technical_debt), which slows down further development of the analysis. This can be necessary for delivering to short deadlines, but time should be set aside to address this for continued development of the analysis.
+Despite the initial cost of developing technical skills, [evidence shows that applying good practices increases the efficiency of code development and maintainability of the code](https://www.devops-research.com/research.html). There are number of case studies that describe how [good quality assurance practices have improved government analysis](https://analysisfunction.civilservice.gov.uk/support/reproducible-analytical-pipelines/rap-case-studies/).
+
+Not following good practices creates [technical debt](https://en.wikipedia.org/wiki/Technical_debt), which slows down further development of the analysis. This can be necessary for delivering to short deadlines, but time should be set aside to address this for continued development of the analysis.
 
 Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with more in-depth assurance of outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -92,5 +92,6 @@ The practices outlined below should be applied proportionately to the business r
 
 ### How would we do a dual run?
 
-* For the highest risk analysis, the program should be written twice separately or with different tools.
-* Where possible, outputs should be compared between the runs for a variety of realistic inputs. 
+* For the highest risk analysis, the results of your analysis should be compared from two independent calculations (i.e. one from another tool or software).
+* Where possible, outputs should be compared between analysis using a variety of realistic inputs.
+* You may also wish to parallel run the new analysis system with a legacy approach, to quantify changes or improvements to the analysis.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -16,41 +16,75 @@ The practices outlined below should be applied proportionately to the business r
 
 * The methodology and data should be suitable for the question being asked.
 * The analysis tools that your team use should have some rationale for being chosen.
-* Users can be consulted throughout the development process.
+* Users should be consulted throughout the development process.
 * The program should be maintainable if it will be re-used.
+
+
+### What happens when the analysis fails to run?
+
+* When code fails to run, it should provide informative error messages to describe the problem.
+* Errors or warnings might also be raised when data validation is not met.
+
+### How easy is it to adjust the way that the analysis runs?
+
+* Configuration of the code that might change should be easily identified from the code.
+* Ideally separate configuration files are used to store these options.
+
+### How are you storing input data?
+
+* Input data should be versioned, so that analysis outputs can be reproduced.
+* Data should be stored in an open format (e.g. CSV and ODS), not formats that are restricted to proprietary software like SAS and Stata. 
+* Large or complex datasets should be stored in a database.
 
 ### How have you specified the analysis?
 
-The package should have an accompanying specification. The specification should show how data are transferred from function to function. The specification helps reviewers to understand the code. Well-specified packages are easier to maintain.
+* The code should have an accompanying specification.
+* The specification should show how data are transferred from function to function.
+* The specification helps reviewers to understand the code. Well-specified code is easier to understand and maintain.
 
 ### What does the documentation look like?
 
-Every function should be documented. Function documentation should say what goes in and what comes out. Documentation should be easy to read, accessible, and part of the package. Good documentation should include examples and test data.
+* Every function should be documented.
+* Function documentation should say what goes in and what comes out of each function.
+* Documentation should be easy to read, accessible, and stored closely to the code.
+* Good documentation includes usage examples and test data.
 
 ### How has peer review been done?
 
-Skilled colleagues should conduct internal peer reviews of the code. If the product is high risk an external peer review should be conducted. Peer review should follow a standard procedure like the Best Practice and Impact example.
+* Skilled colleagues should conduct internal peer reviews of the code.
+* If the product is high risk an external peer review should also be conducted.
+* Peer review should follow a standard procedure.
 
 ### How have you kept track of who made changes and for which reasons?
 
-The code, the documentation, and the peer review should all be version controlled. There should be a clear record of every change and who made it. Each change should have a reason. Reviews should be stored with the version they reviewed.
+* The code, documentation, and peer review should all be version controlled. Git software is most commonly used for this.
+* There should be a clear record of every change and who made it.
+* Each change should have a reason.
+* Reviews should be stored with the version of the analysis that was reviewed.
 
 ### How have you tested the code?
 
-Testing means making sure that the code produces the right outputs for realistic example input data. Good testing is automated 'unit' testing. Combinations of functions, and the entire analysis, should also be tested on small but difficult data.
+* Testing means making sure that the code produces the right outputs for realistic example input data.
+* Good testing is automated 'unit' testing.
+* Each function and the end-to-end analysis should be tested using minimal, realistic data.
 
 ### What have you tested?
 
-Aim for every single function being tested. Tests should account for edge cases like missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs. Reviewers should sign-off that there is enough testing.
-
-### Which other systems have you run this on?
-
-It can be difficult to make sure your code runs where it is needed. Container systems, like Docker, help this to happen. In the absence of this it’s best to start by just trying to open it on a colleague’s system.
+* Aim for every single function being tested
+* Tests should account for edge cases like missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs.
+* Reviewers should sign-off that there is enough testing.
 
 ### What are the dependencies?
 
-Dependencies include anything your package needs to run, including software and package versions. It can be difficult to run code on other systems when dependencies are not documented. Documenting dependencies allows others to reproduce analysis more easily.
+* Dependencies include anything the code needs to run, including software and package versions.
+* It can be difficult to run code on other systems when dependencies are not documented.
+* Documenting dependencies allows others to reproduce the analysis more easily.
 
+### Which other systems have you run this on?
+
+* Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this. 
+* Container systems, like Docker, help to create reproducible environments to run code.
 ### How would we do a dual run?
 
-For the highest risk analysis, the program should be written twice separately or with different tools. Where possible, outputs should be compared between the runs for a variety of realistic inputs. 
+* For the highest risk analysis, the program should be written twice separately or with different tools.
+* Where possible, outputs should be compared between the runs for a variety of realistic inputs. 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -78,6 +78,11 @@ These questions can be used throughout the development of the analysis, to asses
 * Function documentation should also include what goes in and what comes out of each function.
 * Where code will be run or re-used by others, documentation should include usage examples and test data.
 
+### What assumptions does the analysis make?
+
+* Assumptions and caveats of the analysis should be recorded close to the code.
+* These must be communicated to users when releasing results from the analysis.
+
 ### How has peer review been done?
 
 * Technical colleagues should conduct internal peer reviews of each change to the code. This will identify issues early on and makes the review process more manageable than reviewing only the final analysis.
@@ -99,11 +104,6 @@ These questions can be used throughout the development of the analysis, to asses
 
 * Documenting the code dependencies allows others to reproduce the analysis more easily.
 * Dependencies include anything the code needs to run, including software and package versions.
-
-### What assumptions does the analysis make?
-
-* Assumptions and caveats of the analysis should be recorded close to the code.
-* These must be communicated to users when releasing results from the analysis.
 
 ### What happens when the analysis fails to run?
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -2,18 +2,18 @@
 
 This section of the guidance is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 
-It aims to help you support your team to apply the good quality assurance practices described in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Proccesses that appliy these good practices are referred to as a reproducible analytical pipelines (RAP).
+It aims to help you support your team to apply the good quality assurance practices described in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Processes that apply these good practices are referred to as a reproducible analytical pipelines (RAP).
 
 Before applying this guidance, you should have a basic awareness of the tools and techniques used to do quality analysis as code - the [introduction to RAP course](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) outlines these. You should also be aware of any specific tools and platforms that are used in your department.
 
 [The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing and managing the development of analysis as code.
 
 
-## Quality assurance is proportional to risk
+## Apply quality assurance proportional to risk
 
 As described by [the Aqua book](https://www.gov.uk/government/publications/the-aqua-book-guidance-on-producing-quality-analysis-for-government), the quality assurance of our analysis should be proportional to the complexity and risk of the analysis.
 
-When managing analytical work, you should not need an in-depth understanding of the analysis code to trust that it is working correclty. However, you should be confident that the approach the team has taken is appropriate given the user need, and that proportionate quality assurance is being applied to the development and running of the analysis.
+When managing analytical work, you should not need an in-depth understanding of the analysis code to trust that it is working correctly. However, you should be confident that the approach the team has taken is appropriate given the user need, and that proportionate quality assurance is being applied to the development and running of the analysis.
 
 You should work with your team to decide on which quality assurance practices are necessary given each piece of analysis. You might find our [](version_control.md) useful templates for defining the target level of assurance. When possible, you should define the target assurance level before starting the analysis.
 
@@ -26,36 +26,39 @@ While quality assurance must be applied relative to the risk and complexity of t
 Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with  in-depth assurance of analysis outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
 ```
 
-## Analysis as code is beneficial
+Note that it is important to maintain skills in the analysis team, to ensure that the analysis can be updated and maintained.
 
-Carrying out analysis as code has many benefits:
-* Reproducible, quality analysis.
-* Greater efficiency and timeliness, through automation.
-* Transparent analysis and quality assurance, increasing trust.
-* Improved business continuity and knowledge management.
 
-Automating a process using code is not sufficient to achieve all of these benefits, without also applying adequate quality assurance.
+## Design quality analysis
 
-Learning from previous projects, we've found that moving to doing analysis as code is most successful when there is: 
-* intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
-* committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
-* motivation for the project and personal development from those working on the project. 
-* access to appropriate tools for the development and deployment of the project. 
-* a plan for collecting requirements and for transitioning the product into business as usual. 
+These questions aim to help you assess the design decisions at the beginning of the analysis.
 
-It is common for transformation of existing processes to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
-
-## Analytical code requires quality assurance
-
-We recommend that you ask your team the following questions to understand the quality assurance that is being applied in their analysis. Good quality assurance should be applied throughout an analysis project, therefore, it is important that the areas outlined below are reviewed regularly.
-
-The practices outlined below should be applied proportionately to the business risk and complexity of the project. Analytical code that doesn't apply quality assurance carries similar risk to other analysis appraoches. Your team should aim to outline what adequate quality assurance looks like early on in a project. These questions can then be used throughout the project to assess whether this target is being met, or whether the team are moving towards this goal.
-
-### Why have your chosen to do things this way?
+### Why have you chosen to do things this way?
 
 * The methodology and data should be suitable for the question being asked.
-* Your team should be using open-source analysis tools. They should be able to explain why they have chosen these tools and why they are confident that they are fit for purpose.
-* Users should be consulted throughout the development process, to ensure that their need is being met.
+* The analysis should be carried out using open-source analysis tools, wherever possible. Your team should be able to explain why they have chosen the analysis tools and why they are confident that they are fit for purpose.
+* The analysis should be developed by more than one individual, to allow pair programming and peer review. This increases the sustainability of the analysis.
+* Users should be consulted at the beginning and throughout the development process, to ensure that their needs are met.
+
+### How are you storing input data?
+
+* Input data should be versioned, so that analysis outputs can be reproduced.
+* Data should be stored in an open format (e.g. CSV or ODS), not formats that are restricted to proprietary software like SAS and Stata. 
+* Large or complex datasets should be stored in a database.
+* You should monitor the data quality, following [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+
+### How will you keep track of changes to the code and why they were made?
+
+* The code, documentation, and peer reviews should all be version controlled. Git software is most commonly used for this.
+* Ideally the code is developed on an open source code platform, like GitHub. This transparency increases your users trust in the analysis.
+* There should be a clear record of every change and who made it.
+* Each change should be linked to a reason, for example, a new requirement or an issue in the existing code.
+* Reviews of changes should be stored with the version of the analysis that was reviewed.
+
+
+## Quality assure throughout development
+
+These questions can be used throughout the development of the analysis, to assess how the team are progressing towards the target quality assurance practices that you have agreed.
 
 ### How is your code structured?
 
@@ -67,49 +70,39 @@ The practices outlined below should be applied proportionately to the business r
 * Parts of the code that may change should be stored in separate configuration files, so that they can be changed without changing the code.
 * Things that often change in analysis code include input and output file paths, reference dates and model parameters.
 
-### How are you storing input data?
+### How is the analysis documented?
 
-* Input data should be versioned, so that analysis outputs can be reproduced.
-* Data should be stored in an open format (e.g. CSV or ODS), not formats that are restricted to proprietary software like SAS and Stata. 
-* Large or complex datasets should be stored in a database.
-
-### What does the documentation look like?
-
+* Good documentation is essential for business continuity.
 * Every function should be documented in the code, so that it is clear what the function is supposed to do.
 * Function documentation should also include what goes in and what comes out of each function.
 * Where code will be run or re-used by others, documentation should include usage examples and test data.
 
 ### How has peer review been done?
 
-* Technical colleagues should conduct internal peer reviews of the code.
-* Peer review of individual changes to the code will help to identify issues sooner. This is also more manageable than reviewing the complete final analysis.
-* If the product is high risk, an external peer review should also be conducted.
-* Peer review should follow a standard procedure, so that reviews are consistent.
+* Technical colleagues should conduct internal peer reviews of each change to the code. This will identify issues early on and makes the review process more manageable than reviewing only the final analysis.
+* Peer review should follow a standard procedure, so that reviews are consistent. Reviewers should check that each change follows the agreed good practices.
 * There should be evidence that peer reviews are acted on. When issues or concerns are raised, they should be addressed before the analysis is used.
-
-### How have you kept track of who made changes to the code and why?
-
-* The code, documentation, and peer reviews should all be version controlled. Git software is most commonly used for this.
-* There should be a clear record of every change and who made it.
-* Each change should be linked to a reason, for example, a new requirement or an issue in the existing code.
-* Reviews should be stored with the version of the analysis that was reviewed.
+* If the product is high risk, external peer review should also be conducted.
 
 ### How have you tested the code?
 
 * Testing means making sure that the code produces the right outputs for realistic example input data.
 * Automated 'unit' testing should be applied to each function, to ensure that code continues to work after future changes to the code.
 * Each function and the end-to-end analysis should be tested using minimal, realistic data.
-
-### What have you tested?
-
 * Testing should be more extensive on the most important or complex parts of the code. However, ideally every single function should be tested.
 * Tests should account for realistic cases, which might include missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs.
 * Reviewers should sign-off that there is enough testing to assure that the code is working as expected.
+* Each time an error is found in the code, a test should be added to assure that the error does not reoccur.
 
 ### What are the dependencies?
 
 * Documenting the code dependencies allows others to reproduce the analysis more easily.
 * Dependencies include anything the code needs to run, including software and package versions.
+
+### What assumptions does the analysis make?
+
+* Assumptions and caveats of the analysis should be recorded close to the code.
+* These must be communicated to users when releasing results from the analysis.
 
 ### What happens when the analysis fails to run?
 
@@ -117,18 +110,19 @@ The practices outlined below should be applied proportionately to the business r
 * If another team will operate the code, error messages should help users to correct the problem.
 * Errors or warnings might also be raised when data validation is not met.
 
-### How can we further improve the quality of the code?
-
-* Code quality should improve over time, as your team learn more about good practices. They should consider which practices could be applied next to improve the code.
-* You should review training needs in your team and allow time for continous personal development of these practices.
-
 ### Which other systems have you run this on?
 
 * Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this.
+* When the same analysis is run multiple times or on different systems it should give reproducible outcomes.
 * Container systems, like Docker, help to create reproducible environments to run code.
 
-### How would we do a dual run?
+### How does the analysis result differ from the previous analysis?
 
-* For high risk parts of the analysis, the results of this part of the analysis should be compared from two independent calculations (i.e. one from another tool or software).
-* Where possible, outputs should be compared between analysis using a variety of realistic inputs.
-* You may also wish to parallel run new analysis processes with a legacy approach, to quantify changes or improvements to the analysis.
+* When repeating analysis over time, you should compare results between analyses. Large differences in the outcome of the results may indicate an issue with the analysis process.
+* When developing code to replace legacy analysis, you may wish to parallel this with the new method. This will allow you to identify differences and improvements.
+
+### How can we further improve the quality of the analysis?
+
+* Code quality should improve over time, as your team learn more about good practices.
+* The team should be aiming to meet the agreed assurance level, but should also consider which practices could be applied next to improve the code beyond this.
+* You should review training needs in your team and allow time for continuos personal development of these practices.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -23,11 +23,12 @@ While quality assurance must be applied relative to the risk and complexity of t
 
 [The RAP learning pathway](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) provides training in good practices. Then the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html) can be used as a reference to apply these to your analysis. You should identify where each analyst is along the pathway - they should look to develop the next skill in the pathway and apply this, rather than attempting to adopt them all at once.
 
-Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with  in-depth assurance of analysis outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
+Note that it is important to maintain skills in the analysis team for sustainability, to ensure that the analysis can be understood, updated and maintained.
 ```
 
-Note that it is important to maintain skills in the analysis team, to ensure that the analysis can be updated and maintained.
+Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with in-depth assurance of analysis outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
 
+Not following good practices also creates [technical debt](https://en.wikipedia.org/wiki/Technical_debt), which will slow down further development and maintenance of the analysis. This can be necessary for delivering to short deadlines, but time should be set aside to address this for continued development of the analysis.
 
 ## Design quality analysis
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -25,7 +25,7 @@ Carrying out analysis as code has many benefits:
 * Transparent analysis and quality assurance, increasing trust.
 * Improved business continuity and knowledge management.
 
-Automating a process using code is not sufficient to achieve all of the benefits, witout also applying adequate quality assurance.
+Automating a process using code is not sufficient to achieve all of the benefits, without also applying adequate quality assurance.
 
 ## Analytical code requires quality assurance
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -25,7 +25,7 @@ Carrying out analysis as code has many benefits:
 * Transparent analysis and quality assurance, increasing trust.
 * Improved business continuity and knowledge management.
 
-Automating a process using code is not sufficient to achieve all of the benefits, without also applying adequate quality assurance.
+Automating a process using code is not sufficient to achieve all of these benefits, without also applying adequate quality assurance.
 
 ## Analytical code requires quality assurance
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -36,7 +36,7 @@ The practices outlined below should be applied proportionately to the business r
 ### Why have your chosen to do things this way?
 
 * The methodology and data should be suitable for the question being asked.
-* Your team should be using open-source analysis tools. They should be able to explain why they have chosen these tools and why they are confident that they are appropriate and fit for purpose.
+* Your team should be using open-source analysis tools. They should be able to explain why they have chosen these tools and why they are confident that they are fit for purpose.
 * Users should be consulted throughout the development process, to ensure that their need is being met.
 
 ### How is your code structured?

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,12 +1,12 @@
 # Managing analytical code development
 
 ```{note}
-This section is a working draft.
+This section is a draft, while we ensure that it meets user needs.
 
-Please get in touch with feedback or case studies to support the guidance [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or via [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk).
+Please get in touch with feedback or case studies to support the guidance [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or emailing us at [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk).
 ```
 
-This section of the guidance is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
+This section of the guidance is targeted at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 
 It aims to help you support your team to apply the good quality assurance practices described in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Processes that apply these good practices are referred to as a reproducible analytical pipelines (RAP).
 
@@ -23,18 +23,21 @@ When managing analytical work, you should not need an in-depth understanding of 
 
 You should work with your team to decide on which quality assurance practices are necessary given each piece of analysis. You might find our [](version_control.md) useful templates for defining the target level of assurance. When possible, you should define the target assurance level before starting the analysis.
 
-```{important} Develop good practice skills
+```{important}
 
 While quality assurance must be applied relative to the risk and complexity of the analysis, you must consider the skills of your team. It will take time to learn to apply the necessary good practices, so you should support their gradual development of these skills.
 
 [The RAP learning pathway](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) provides training in good practices. Then the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html) can be used as a reference to apply these practices to analysis. You should identify where each analyst is along the pathway - they should look to develop the next skill in the pathway and apply this, rather than attempting to adopt them all at once.
 
-Note that it is important to maintain skills in the analysis team for sustainability, to ensure that the analysis can be understood, updated and maintained.
+Note that it is important to maintain technical skills in the analysis team for sustainability, to ensure that the analysis can be understood, updated and maintained.
 ```
 
-Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with in-depth assurance of analysis outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
+Despite the initial cost of developing technical skills, [evidence shows that applying good practices increases the efficiency of code development and maintainability of the code](https://www.devops-research.com/research.html). Not following good practices creates [technical debt](https://en.wikipedia.org/wiki/Technical_debt), which slows down further development of the analysis. This can be necessary for delivering to short deadlines, but time should be set aside to address this for continued development of the analysis.
 
-Not following good practices also creates [technical debt](https://en.wikipedia.org/wiki/Technical_debt), which will slow down further development and maintenance of the analysis. This can be necessary for delivering to short deadlines, but time should be set aside to address this for continued development of the analysis.
+Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with more in-depth assurance of outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
+
+The remaining parts of this section provide questions that aim to help you assess the quality assurance practices that your team are applying in their analysis.
+
 
 ## Design quality analysis
 
@@ -46,7 +49,7 @@ Understanding user needs ensures that the analysis is valuable.
 
 * There should be a plan to consult users at the beginning and throughout the development process, to ensure that their needs are being met.
 * The methodology and data should be suitable for the question being asked.
-* The analysis should be developed by more than one individual, to allow pair programming and peer review. This increases the sustainability of the analysis.
+* The analysis must be developed by more than one individual, to allow pair programming, peer review and mentoring. This increases the sustainability of analysis.
 * The analysis should be carried out using open-source analysis tools, wherever possible. Your team should be able to explain why they have chosen the analysis tools and why they are confident that they are fit for purpose.
 
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -13,7 +13,7 @@ It is common for this kind of transformation to identify quality issues in the c
 
 [The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing and managing the development of analysis.
 
-The rest of this page describes the benefits of doing analysis as code and aims to help you ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices are refered to as reproducible analytical pipelines (RAP).
+The rest of this page describes the benefits of doing analysis as code and aims to help you ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices is referred to as a reproducible analytical pipeline (RAP).
 
 Analysis team managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -33,7 +33,7 @@ Note that it is important to maintain skills in the analysis team, to ensure tha
 
 These questions aim to help you assess the design decisions at the beginning of the analysis.
 
-### Why have you chosen to do things this way?
+### Why have you chosen to do the analysis this way?
 
 * The methodology and data should be suitable for the question being asked.
 * The analysis should be carried out using open-source analysis tools, wherever possible. Your team should be able to explain why they have chosen the analysis tools and why they are confident that they are fit for purpose.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,4 +1,4 @@
-# Managers guide
+# Managing analytical code development
 
 This section is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -21,7 +21,7 @@ When managing analytical work, you should not need an in-depth understanding of 
 
 You should work with your team to decide on which quality assurance practices are necessary given each piece of analysis. You might find our [](version_control.md) useful templates for defining the target level of assurance. When possible, you should define the target assurance level before starting the analysis.
 
-```{important} Developing good practice skills
+```{important} Develop good practice skills
 
 While quality assurance must be applied relative to the risk and complexity of the analysis, you must consider the skills of your team. It will take time to learn to apply the necessary good practices, so you should support their gradual development of these skills.
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -2,36 +2,36 @@
 
 This section is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 
-Learning from previous projects, we've found that successfully developing analytical code requires: 
+Learning from previous projects, we've found that moving from traditional analysis approaches to developing analysis as code requires: 
 * Intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
 * Committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
 * Motivation for the project and personal development from those working on the project. 
 * Having appropriate tools available for the development and deployment of the project. 
 * A plan for requirement collection and transitioning the product into business as usual. 
 
-It is common for process transformation to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
+It is common for this kind of transformation to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
 
-Analytical managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
+[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing and managing the development of analysis.
 
-[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing your analysis.
+The rest of this page describes the benefits of doing analysis as code and aims to help you ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices are refered to as reproducible analytical pipelines (RAP).
 
-The rest of this page describes how you can ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices are refered to as reproducible analytical pipelines (RAP).
+Analysis team managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
 
 ## Analysis as code is beneficial
 
 Carrying out analysis as code has many benefits:
-* Reproducible, quality analysis
+* Reproducible, quality analysis.
 * Greater efficiency and timeliness, through automation.
 * Transparent analysis and quality assurance, increasing trust.
 * Improved business continuity and knowledge management.
 
-Achieving all of these benefits and mitigating risks associated with analysis requires adequate quality assurance.
+Automating a process using code is not sufficient to achieve all of the benefits, witout also applying adequate quality assurance.
 
 ## Analytical code requires quality assurance
 
 We recommend that you ask your team the following questions to understand the quality assurance that is being applied in their analysis. Good quality assurance should be applied throughout an analysis project, therefore, it is important that the areas outlined below are reviewed regularly.
 
-The practices outlined below should be applied proportionately to the business risk and complexity of the project. Analytical code that doesn't apply these practices carries similar risk to other analysis appraoches. You should aim to establish what adequate quality assurance looks like early on in a project. These questions can then be used throughout the project to assess whether this goal is being met, or that the team are moving towards this goal.
+The practices outlined below should be applied proportionately to the business risk and complexity of the project. Analytical code that doesn't apply quality assurance carries similar risk to other analysis appraoches. Your team should aim to outline what adequate quality assurance looks like early on in a project. These questions can then be used throughout the project to assess whether this target is being met, or whether the team are moving towards this goal.
 
 ### Why have your chosen to do things this way?
 
@@ -39,22 +39,16 @@ The practices outlined below should be applied proportionately to the business r
 * Your team should be using open-source analysis tools, with a reason for each given tool being chosen.
 * Users should be consulted throughout the development process, to ensure that their need is being met.
 
-### What happens when the analysis fails to run?
-
-* When code fails to run, it should provide informative error messages to describe the problem.
-* If another team will operate the code, error messages should help users to correct the problem.
-* Errors or warnings might also be raised when data validation is not met.
-
 ### How is your code structured?
 
 * Logic should be written as functions, so that it can be reused consistently and tested.
-* The code that executes the analysis should be very readable.
-* Similar functions should be grouped together in separate files, so that it is easy to identify them.
+* Related functions should be grouped together in the same file, so that it is easy to find them.
 
 ### How easy is it to adjust the way that the analysis runs?
 
 * Parts of the code that may change should be stored in separate configuration files, so that they can be changed without changing the code.
 * Things that often change in analysis code include input and output file paths, reference dates and model parameters.
+
 ### How are you storing input data?
 
 * Input data should be versioned, so that analysis outputs can be reproduced.
@@ -69,27 +63,27 @@ The practices outlined below should be applied proportionately to the business r
 
 ### How has peer review been done?
 
-* Skilled colleagues should conduct internal peer reviews of the code.
-* Peer review should ideally be carried out on individual changes to the code, rather than the final analysis.
+* Technical colleagues should conduct internal peer reviews of the code.
+* Peer review of individual changes to the code will help to identify issues sooner. This is also more manageable than reviewing the complete final analysis.
 * If the product is high risk, an external peer review should also be conducted.
 * Peer review should follow a standard procedure, so that reviews are consistent.
 
 ### How have you kept track of who made changes to the code and why?
 
-* The code, documentation, and peer review should all be version controlled. Git software is most commonly used for this.
+* The code, documentation, and peer reviews should all be version controlled. Git software is most commonly used for this.
 * There should be a clear record of every change and who made it.
-* Each change should be linked to a reason, for example, a new requirement or a bug in the existing code.
+* Each change should be linked to a reason, for example, a new requirement or an issue in the existing code.
 * Reviews should be stored with the version of the analysis that was reviewed.
 
 ### How have you tested the code?
 
 * Testing means making sure that the code produces the right outputs for realistic example input data.
-* Automated 'unit' testing should be applied, to ensure that code continues to work after future changes to the code.
+* Automated 'unit' testing should be applied to each function, to ensure that code continues to work after future changes to the code.
 * Each function and the end-to-end analysis should be tested using minimal, realistic data.
 
 ### What have you tested?
 
-* Aim for every single function being tested.
+* Testing should be more extensive on the most important or complex parts of the code. However, ideally every single function should be tested.
 * Tests should account for realistic cases, which might include missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs.
 * Reviewers should sign-off that there is enough testing to assure that the code is working as expected.
 
@@ -97,6 +91,12 @@ The practices outlined below should be applied proportionately to the business r
 
 * Documenting the code dependencies allows others to reproduce the analysis more easily.
 * Dependencies include anything the code needs to run, including software and package versions.
+
+### What happens when the analysis fails to run?
+
+* When code fails to run, it should provide informative error messages to describe the problem.
+* If another team will operate the code, error messages should help users to correct the problem.
+* Errors or warnings might also be raised when data validation is not met.
 
 ### How can we further improve the quality of the code?
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -4,7 +4,7 @@ This section is aimed at those who manage analysts in government or act as produ
 
 Analytical managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
 
-For a better understanding of the tools that your team use for analysis, you might look at the [Awareness of Coding Tools](https://learninghub.ons.gov.uk/enrol/index.php?id=530) course on th GSS Learning Hub.
+For a better understanding of the tools that your team use for analysis, you might look at the [Awareness of Coding Tools](https://learninghub.ons.gov.uk/enrol/index.php?id=530) course on the GSS Learning Hub.
 
 ## Questions around quality assurance
 
@@ -52,7 +52,7 @@ The practices outlined below should be applied proportionately to the business r
 ### How has peer review been done?
 
 * Skilled colleagues should conduct internal peer reviews of the code.
-* If the product is high risk an external peer review should also be conducted.
+* If the product is high risk, an external peer review should also be conducted.
 * Peer review should follow a standard procedure.
 
 ### How have you kept track of who made changes and for which reasons?
@@ -80,10 +80,16 @@ The practices outlined below should be applied proportionately to the business r
 * It can be difficult to run code on other systems when dependencies are not documented.
 * Documenting dependencies allows others to reproduce the analysis more easily.
 
+### How can we further improve the quality of the code?
+
+* Code quality should improve over time, as your team learn more about good practices. They should consider which practices could be applied next to improve the code.
+* You should review training needs in your team and allow time for continous personal development of these practices.
+
 ### Which other systems have you run this on?
 
 * Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this. 
 * Container systems, like Docker, help to create reproducible environments to run code.
+
 ### How would we do a dual run?
 
 * For the highest risk analysis, the program should be written twice separately or with different tools.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -2,7 +2,7 @@
 
 This section is aimed at those who manage analysts in government or act as product owners for analytical code.
 
-Learning from previous projects, we've found that management of reproducible analytical pipeline (RAP) projects requires: 
+Learning from previous projects, we've found that successful reproducible analytical pipeline (RAP) projects require: 
 * Intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
 * Committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
 * Motivation for the project and personal development from those working on the project. 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -3,6 +3,8 @@
 ```{note}
 This section is a draft, while we ensure that it meets user needs.
 
+It would benefit from case studies that demonstrate how to decide what level of quality assurance a piece of analysis requires.
+
 Please get in touch with feedback or case studies to support the guidance [by creating a GitHub Issue](https://github.com/best-practice-and-impact/qa-of-code-guidance/issues) or emailing us at [Analysis.Function@ons.gov.uk](mailto:Analysis.Function@ons.gov.uk).
 ```
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -2,9 +2,16 @@
 
 This section is aimed at those who manage analysts in government or act as product owners for analytical code.
 
-Analytical managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
+Learning from previous projects, we've found that management of reproducible analytical pipeline (RAP) projects requires: 
+* Intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
+* Committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
+* Motivation for the project and personal development from those working on the project. 
+* Having appropriate tools available for the development and deployment of the project. 
+* A plan for requirement collection and transitioning the product into business as usual. 
 
-For a better understanding of the tools that your team use for analysis, you might look at the [Awareness of Coding Tools](https://learninghub.ons.gov.uk/enrol/index.php?id=530) course on the GSS Learning Hub.
+It is common for RAP transformation to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
+
+Analytical managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
 
 ## Questions around quality assurance
 
@@ -18,7 +25,6 @@ The practices outlined below should be applied proportionately to the business r
 * The analysis tools that your team use should have some rationale for being chosen.
 * Users should be consulted throughout the development process.
 * The program should be maintainable if it will be re-used.
-
 
 ### What happens when the analysis fails to run?
 
@@ -95,3 +101,7 @@ The practices outlined below should be applied proportionately to the business r
 * For the highest risk analysis, the results of your analysis should be compared from two independent calculations (i.e. one from another tool or software).
 * Where possible, outputs should be compared between analysis using a variety of realistic inputs.
 * You may also wish to parallel run the new analysis system with a legacy approach, to quantify changes or improvements to the analysis.
+
+# Other resources
+
+For a better understanding of the tools that your team use for analysis, you might look at the [Awareness of Coding Tools](https://learninghub.ons.gov.uk/enrol/index.php?id=530) course on the GSS Learning Hub.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,0 +1,56 @@
+# Managers guide
+
+This section is aimed at those who manage analysts in government or act as product owners for analytical code.
+
+Analytical managers should not need an in-depth understanding of the code produced by their team. However, they should be able to asses whether adequate quality assurance is being applied to the development of the analysis.
+
+For a better understanding of the tools that your team use for analysis, you might look at the [Awareness of Coding Tools](https://learninghub.ons.gov.uk/enrol/index.php?id=530) course on th GSS Learning Hub.
+
+## Questions around quality assurance
+
+We recommend that you ask your team the following questions to understand the quality assurance that is being applied in their analysis. Good quality assurance should be applied throughout an analysis project, therefore, it is important that the areas outlined below are reviewed regularly.
+
+The practices outlined below should be applied proportionately to the business risk and complexity of the project. You should aim to establish what adequate quality assurance looks like at the beginning of a project. These questions can then be used throughout the project to assess whether this goal is being met.
+
+### Why have your chosen to do things this way?
+
+* The methodology and data should be suitable for the question being asked.
+* The analysis tools that your team use should have some rationale for being chosen.
+* Users can be consulted throughout the development process.
+* The program should be maintainable if it will be re-used.
+
+### How have you specified the analysis?
+
+The package should have an accompanying specification. The specification should show how data are transferred from function to function. The specification helps reviewers to understand the code. Well-specified packages are easier to maintain.
+
+### What does the documentation look like?
+
+Every function should be documented. Function documentation should say what goes in and what comes out. Documentation should be easy to read, accessible, and part of the package. Good documentation should include examples and test data.
+
+### How has peer review been done?
+
+Skilled colleagues should conduct internal peer reviews of the code. If the product is high risk an external peer review should be conducted. Peer review should follow a standard procedure like the Best Practice and Impact example.
+
+### How have you kept track of who made changes and for which reasons?
+
+The code, the documentation, and the peer review should all be version controlled. There should be a clear record of every change and who made it. Each change should have a reason. Reviews should be stored with the version they reviewed.
+
+### How have you tested the code?
+
+Testing means making sure that the code produces the right outputs for realistic example input data. Good testing is automated 'unit' testing. Combinations of functions, and the entire analysis, should also be tested on small but difficult data.
+
+### What have you tested?
+
+Aim for every single function being tested. Tests should account for edge cases like missing data, zeroes, infinities, negative numbers, wrong data types, and invalid inputs. Reviewers should sign-off that there is enough testing.
+
+### Which other systems have you run this on?
+
+It can be difficult to make sure your code runs where it is needed. Container systems, like Docker, help this to happen. In the absence of this it’s best to start by just trying to open it on a colleague’s system.
+
+### What are the dependencies?
+
+Dependencies include anything your package needs to run, including software and package versions. It can be difficult to run code on other systems when dependencies are not documented. Documenting dependencies allows others to reproduce analysis more easily.
+
+### How would we do a dual run?
+
+For the highest risk analysis, the program should be written twice separately or with different tools. Where possible, outputs should be compared between the runs for a variety of realistic inputs. 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -1,21 +1,30 @@
 # Managing analytical code development
 
-This section is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
+This section of the guidance is aimed at those who manage data analysis/science/engineering work in government or those acting as product owners for analytical products.
 
-Learning from previous projects, we've found that moving from traditional analysis approaches to developing analysis as code requires: 
-* Intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
-* Committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
-* Motivation for the project and personal development from those working on the project. 
-* Having appropriate tools available for the development and deployment of the project. 
-* A plan for requirement collection and transitioning the product into business as usual. 
+It aims to help you support your team to apply the good quality assurance practices described in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Proccesses that appliy these good practices are referred to as a reproducible analytical pipelines (RAP).
 
-It is common for this kind of transformation to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
+Before applying this guidance, you should have a basic awareness of the tools and techniques used to do quality analysis as code - the [introduction to RAP course](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) outlines these. You should also be aware of any specific tools and platforms that are used in your department.
 
-[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing and managing the development of analysis.
+[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing and managing the development of analysis as code.
 
-The rest of this page describes the benefits of doing analysis as code and aims to help you ensure that your team are applying the good quality assurance practices outlined in the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html). Code that applies these good practices is referred to as a reproducible analytical pipeline (RAP).
 
-Analysis team managers should not need an in-depth understanding of the code produced by their team. However, they should be confident that the approach the team has taken is appropriate given the user need, and that proportionate quality assurance is being applied to the development and running of the analysis.
+## Quality assurance is proportional to risk
+
+As described by [the Aqua book](https://www.gov.uk/government/publications/the-aqua-book-guidance-on-producing-quality-analysis-for-government), the quality assurance of our analysis should be proportional to the complexity and risk of the analysis.
+
+When managing analytical work, you should not need an in-depth understanding of the analysis code to trust that it is working correclty. However, you should be confident that the approach the team has taken is appropriate given the user need, and that proportionate quality assurance is being applied to the development and running of the analysis.
+
+You should work with your team to decide on which quality assurance practices are necessary given each piece of analysis. You might find our [](version_control.md) useful templates for defining the target level of assurance. When possible, you should define the target assurance level before starting the analysis.
+
+```{important} Developing good practice skills
+
+While quality assurance must be applied relative to the risk and complexity of the analysis, you must consider the skills of your team. It will take time to learn to apply the necessary good practices, so you should support their gradual development of these skills.
+
+[The RAP learning pathway](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) provides training in good practices. Then the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html) can be used as a reference to apply these to your analysis. You should identify where each analyst is along the pathway - they should look to develop the next skill in the pathway and apply this, rather than attempting to adopt them all at once.
+
+Where quality assurance of the code doesn't meet your target level of assurance, for example where there is limited time or skill, then it is necessary to supplement this with  in-depth assurance of analysis outputs. This might include dual running the analysis with an independent system and consistency checks across the output data.
+```
 
 ## Analysis as code is beneficial
 
@@ -26,6 +35,15 @@ Carrying out analysis as code has many benefits:
 * Improved business continuity and knowledge management.
 
 Automating a process using code is not sufficient to achieve all of these benefits, without also applying adequate quality assurance.
+
+Learning from previous projects, we've found that moving to doing analysis as code is most successful when there is: 
+* intention to transform and improve the quality of the wider business process around the project, not just automating an existing process. 
+* committed, skilled resource for the duration of the project and for ongoing maintenance for the life span of the product. 
+* motivation for the project and personal development from those working on the project. 
+* access to appropriate tools for the development and deployment of the project. 
+* a plan for collecting requirements and for transitioning the product into business as usual. 
+
+It is common for transformation of existing processes to identify quality issues in the current process. This should be seen as an opportunity to improve the quality of the process.
 
 ## Analytical code requires quality assurance
 
@@ -114,7 +132,3 @@ The practices outlined below should be applied proportionately to the business r
 * For high risk parts of the analysis, the results of this part of the analysis should be compared from two independent calculations (i.e. one from another tool or software).
 * Where possible, outputs should be compared between analysis using a variety of realistic inputs.
 * You may also wish to parallel run new analysis processes with a legacy approach, to quantify changes or improvements to the analysis.
-
-# Other resources
-
-For a better understanding of the tools that your team use for analysis, you might look at the [Awareness of Coding Tools](https://learninghub.ons.gov.uk/enrol/index.php?id=530) course on the GSS Learning Hub.

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -14,7 +14,7 @@ It aims to help you support your team to apply the good quality assurance practi
 
 Before applying this guidance, you should have a basic awareness of the tools and techniques used to do quality analysis as code - the [introduction to RAP course](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) outlines these. You should also be aware of any specific tools and platforms that are used in your department.
 
-[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which includes analysis. You should use this when designing and managing the development of analysis as code.
+[The Government Service Standard](https://www.gov.uk/service-manual/service-standard) outlines best practices for creating public services, which include analysis. You should use this when designing and managing the development of analysis as code.
 
 
 ## Apply quality assurance proportional to risk
@@ -23,7 +23,7 @@ As described by [the Aqua book](https://www.gov.uk/government/publications/the-a
 
 When managing analytical work, you should not need an in-depth understanding of the analysis code to trust that it is working correctly. However, you should be confident that the approach the team has taken is appropriate given the user need, and that proportionate quality assurance is being applied to the development and running of the analysis.
 
-You should work with your team to decide on which quality assurance practices are necessary given each piece of analysis. You might find our [](version_control.md) useful templates for defining the target level of assurance. When possible, you should define the target assurance level before starting the analysis.
+You should work with your team to decide on which quality assurance practices are necessary given each piece of analysis. You might find our [](checklists.md) useful templates for defining the target level of assurance. When possible, you should define the target assurance level before starting the analysis.
 
 ```{important}
 

--- a/book/managers_guide.md
+++ b/book/managers_guide.md
@@ -27,7 +27,7 @@ You should work with your team to decide on which quality assurance practices ar
 
 While quality assurance must be applied relative to the risk and complexity of the analysis, you must consider the skills of your team. It will take time to learn to apply the necessary good practices, so you should support their gradual development of these skills.
 
-[The RAP learning pathway](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) provides training in good practices. Then the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html) can be used as a reference to apply these to your analysis. You should identify where each analyst is along the pathway - they should look to develop the next skill in the pathway and apply this, rather than attempting to adopt them all at once.
+[The RAP learning pathway](https://learninghub.ons.gov.uk/course/view.php?name=intro_to_RAP) provides training in good practices. Then the wider [Quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html) can be used as a reference to apply these practices to analysis. You should identify where each analyst is along the pathway - they should look to develop the next skill in the pathway and apply this, rather than attempting to adopt them all at once.
 
 Note that it is important to maintain skills in the analysis team for sustainability, to ensure that the analysis can be understood, updated and maintained.
 ```
@@ -42,22 +42,30 @@ These questions aim to help you assess the design decisions at the beginning of 
 
 ### Why have you chosen to do the analysis this way?
 
+Understanding user needs ensures that the analysis is valuable.
+
+* There should be a plan to consult users at the beginning and throughout the development process, to ensure that their needs are being met.
 * The methodology and data should be suitable for the question being asked.
-* The analysis should be carried out using open-source analysis tools, wherever possible. Your team should be able to explain why they have chosen the analysis tools and why they are confident that they are fit for purpose.
 * The analysis should be developed by more than one individual, to allow pair programming and peer review. This increases the sustainability of the analysis.
-* Users should be consulted at the beginning and throughout the development process, to ensure that their needs are met.
+* The analysis should be carried out using open-source analysis tools, wherever possible. Your team should be able to explain why they have chosen the analysis tools and why they are confident that they are fit for purpose.
+
 
 ### How are you storing input data?
+
+Versioning input data ensures that we can reproduce our analysis.
 
 * Input data should be versioned, so that analysis outputs can be reproduced.
 * Data should be stored in an open format (e.g. CSV or ODS), not formats that are restricted to proprietary software like SAS and Stata. 
 * Large or complex datasets should be stored in a database.
-* You should monitor the data quality, following [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+* You should monitor the quality of data, following [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+
 
 ### How will you keep track of changes to the code and why they were made?
 
+[Version control](version_control.md) of changes provides an audit trail.
+
 * The code, documentation, and peer reviews should all be version controlled. Git software is most commonly used for this.
-* Ideally the code is developed on an open source code platform, like GitHub. This transparency increases your users trust in the analysis.
+* The code should be developed on an open source code platform, like GitHub. This transparency increases your users trust in the analysis.
 * There should be a clear record of every change and who made it.
 * Each change should be linked to a reason, for example, a new requirement or an issue in the existing code.
 * Reviews of changes should be stored with the version of the analysis that was reviewed.
@@ -67,36 +75,66 @@ These questions aim to help you assess the design decisions at the beginning of 
 
 These questions can be used throughout the development of the analysis, to assess how the team are progressing towards the target quality assurance practices that you have agreed.
 
+
 ### How is your code structured?
+
+[Modular code](modular_code.md) makes it easier to understand, update and reuse the code.
 
 * Logic should be written as functions, so that it can be reused consistently and tested.
 * Related functions should be grouped together in the same file, so that it is easy to find them.
+* Logic with different responsibilities (e.g. reading data versus transforming data) should be clearly separated.
+* When code can be reused for other analyses, it should be stored and shared as a package.
+
 
 ### How easy is it to adjust the way that the analysis runs?
 
-* Parts of the code that may change should be stored in separate configuration files, so that they can be changed without changing the code.
+[Configuration files](configuration.md) allow you to change the way the code runs without editing the code.
+
+* Parts of the code that may change should be stored in separate configuration files.
 * Things that often change in analysis code include input and output file paths, reference dates and model parameters.
+
 
 ### How is the analysis documented?
 
-* Good documentation is essential for business continuity.
+[Code documentation](code_documentation.md) is essential for business continuity and sustainability.
+
 * Every function should be documented in the code, so that it is clear what the function is supposed to do.
-* Function documentation should also include what goes in and what comes out of each function.
+* Function documentation should include what goes in and what comes out of each function.
 * Where code will be run or re-used by others, documentation should include usage examples and test data.
 
+
+### What are the dependencies?
+
+[Project documentation](project_documentation.md) ensures that others can reproduce our analysis.
+
+* User instructions should be provided for running the analysis.
+* Software and package versions should be documented with the code. Typically package versions are recorded using `setup.py` and `requirements.txt` files (Python) or `DESCRIPTION` file (R).
+* Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this.
+* When the same analysis is run multiple times or on different systems it should give reproducible outcomes.
+* Container systems, like Docker, help to create reproducible environments to run code.
+
+
 ### What assumptions does the analysis make?
+
+Transparency of our analysis increases trust.
 
 * Assumptions and caveats of the analysis should be recorded close to the code.
 * These must be communicated to users when releasing results from the analysis.
 
+
 ### How has peer review been done?
+
+[Peer review](peer_review.md) increases the quality of our analysis and transfers skills and knowledge.
 
 * Technical colleagues should conduct internal peer reviews of each change to the code. This will identify issues early on and makes the review process more manageable than reviewing only the final analysis.
 * Peer review should follow a standard procedure, so that reviews are consistent. Reviewers should check that each change follows the agreed good practices.
 * There should be evidence that peer reviews are acted on. When issues or concerns are raised, they should be addressed before the analysis is used.
 * If the product is high risk, external peer review should also be conducted.
 
+
 ### How have you tested the code?
+
+[Testing](testing_code.md) assures us that the code is working correctly.
 
 * Testing means making sure that the code produces the right outputs for realistic example input data.
 * Automated 'unit' testing should be applied to each function, to ensure that code continues to work after future changes to the code.
@@ -106,30 +144,28 @@ These questions can be used throughout the development of the analysis, to asses
 * Reviewers should sign-off that there is enough testing to assure that the code is working as expected.
 * Each time an error is found in the code, a test should be added to assure that the error does not reoccur.
 
-### What are the dependencies?
-
-* Documenting the code dependencies allows others to reproduce the analysis more easily.
-* Dependencies include anything the code needs to run, including software and package versions.
 
 ### What happens when the analysis fails to run?
+
+Recording and reporting errors provides an audit trail and makes it easier for users to correctly use the code.
 
 * When code fails to run, it should provide informative error messages to describe the problem.
 * If another team will operate the code, error messages should help users to correct the problem.
 * Errors or warnings might also be raised when data validation is not met.
+* When code is run in production, errors should be recorded or logged.
 
-### Which other systems have you run this on?
-
-* Code should not be dependent on a specific computer to run. Running it on a colleague's system can help to check this.
-* When the same analysis is run multiple times or on different systems it should give reproducible outcomes.
-* Container systems, like Docker, help to create reproducible environments to run code.
 
 ### How does the analysis result differ from the previous analysis?
+
+Comparing analysis to previous results can help to ensure reproducibility and identify errors.
 
 * When repeating analysis over time, you should compare results between analyses. Large differences in the outcome of the results may indicate an issue with the analysis process.
 * When developing code to replace legacy analysis, you may wish to parallel this with the new method. This will allow you to identify differences and improvements.
 
+
 ### How can we further improve the quality of the analysis?
 
-* Code quality should improve over time, as your team learn more about good practices.
+Code quality improves over time, as your team learn more about good practices.
+
 * The team should be aiming to meet the agreed assurance level, but should also consider which practices could be applied next to improve the code beyond this.
 * You should review training needs in your team and allow time for continuos personal development of these practices.

--- a/book/principles.md
+++ b/book/principles.md
@@ -104,7 +104,7 @@ Producing analysis, such as official statistics, can be time-consuming and pains
 We need to make sure that our outputs are both accurate and timely.
 We aim to develop effective and efficient analytical workflows that are repeatable and sustainable over time.
 These workflows should follow the principles of reproducible analysis. 
-We call these [Reproducible Analytical Pipelines (RAP)](https://gss.civilservice.gov.uk/reproducible-analytical-pipelines/).
+We call these [Reproducible Analytical Pipelines (RAP)](https://analysisfunction.civilservice.gov.uk/support/reproducible-analytical-pipelines/).
 
 Reproducible analysis is still not widely practised across government.
 Many analysts use proprietary (paid-for) analytical tools like SAS or SPSS in combination with programs like Excel, Word or Acrobat to create statistical products. 
@@ -121,5 +121,5 @@ Coupled with version control and software management platforms like [Git](https:
 RAP was [first piloted in the Government Statistical Service in 2017](https://dataingovernment.blog.gov.uk/2017/03/27/reproducible-analytical-pipeline/) by analysts in the Department for Digital, Culture, Media and Sport (DCMS) and the Department for Education (DfE). 
 They collaborated with data scientists from the Government Digital Service (GDS) to automate the production of statistical bulletins.
 
-To support the adoption of RAP across government, there is a network of [RAP champions](https://gss.civilservice.gov.uk/about-us/champion-networks/reproducible-analytical-pipeline-rap-champions/). 
+To support the adoption of RAP across government, there is a network of [RAP champions](https://analysisfunction.civilservice.gov.uk/support/reproducible-analytical-pipelines/reproducible-analytical-pipeline-rap-champions/). 
 RAP champions are responsible for promoting reproducible analysis through the use of reproducible analytical pipelines, and supporting others who want to develop RAP in their own departments.


### PR DESCRIPTION
Migrating a set of questions that @alexander-newton previously put together from Word to .md.
Moved to a bulleted format, but this doesn't currently fit all of the text.
Also adapted questions to fit more closely with code QA checklist

@alexander-newton, I think we should look to collect user requirements to guide this

## Requirements from users:
- [x]  convince non-technical managers to invest the time and effort in moving a project up the RAP levels, even if it's [already] in a fit state for delivery to a customer
- [x] reinforce the risks associated with technical debt (and our responsibility as civil servants)
- [x] is dual running still necessary when working with code like this, could a proper peer review and approval process, and in built automated checks / unit tests be the way forward instead and remove the need to 'dual run' as we would with manual processes?
- [x] address that review should be done during development, not at the end