### PR TITLE
Fix suggest edit button dead link

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -7,6 +7,7 @@ logo: "./_static/duck_book_logo.svg"
 repository:
   url: https://github.com/best-practice-and-impact/qa-of-code-guidance
   path_to_book: book
+  branch: main
 
 html:
   home_page_in_navbar: false


### PR DESCRIPTION
Fixed the dead link on the Suggest Edit button that was caused by renaming master to main. Just added an optional argument in the html in the config to specify the main branch, as the default is master.