### PR TITLE
Fix spelling of parameterise and make consistent across book

### DIFF
--- a/book/checklist_higher.md
+++ b/book/checklist_higher.md
@@ -107,7 +107,7 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Stakeholder or user acceptance sign-offs are recorded near to the code.
 - Test are automatically run and recorded using continuous integration or git hooks.
 - The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
+- Test code is clean and readable. Tests make use of fixtures and parameterisation to reduce repetition.
 - Formal user acceptance testing is conducted and recorded.
 - Integration tests ensure that multiple units of code work together as expected.
 
@@ -256,7 +256,7 @@ Quality assurance checklist from
 - [ ] Stakeholder or user acceptance sign-offs are recorded near to the code.
 - [ ] Test are automatically run and recorded using continuous integration or git hooks.
 - [ ] The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- [ ] Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
+- [ ] Test code is clean and readable. Tests make use of fixtures and parameterisation to reduce repetition.
 - [ ] Formal user acceptance testing is conducted and recorded.
 - [ ] Integration tests ensure that multiple units of code work together as expected.
 

--- a/book/checklist_higher.md
+++ b/book/checklist_higher.md
@@ -12,14 +12,16 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Low level functions and classes carry out one specific task. As such, there is only one reason to change each function.
 - Repetition in the code is minimalised. For example, by moving reusable code into functions or classes.
 - Objects and functions are open for extension but closed for modification; functionality can be extended without modifying the source code.
-- Subclasses retain the functionality of their parent class while adding new functionality. Parent class objects can be replaced with instances of the subclass and still work as expected.
+- Subclasses retain the functionality of their parent class while adding new functionality. Parent class objects can be replaced with instances of the subclass
+ and still work as expected.
 
 ### Good coding practices
 
 - Names used in the code are informative and concise.
 - Names used in the code are explicit, rather than implicit.
 - Code logic is clear and avoids unnecessary complexity.
-- Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/) and [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
+- Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/)
+ and [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
 
 ### Project structure
 
@@ -32,9 +34,11 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Comments are kept up to date, so they do not confuse the reader.
 - Code is not commented out to adjust which lines of code run.
 - All functions and classes are documented to describe what they do, what inputs they take and what they return.
-- Python code is [documented using docstrings](https://www.python.org/dev/peps/pep-0257/). R code is [documented using `roxygen2` comments](https://cran.r-project.org/web/packages/roxygen2/vignettes/roxygen2.html).
+- Python code is [documented using docstrings](https://www.python.org/dev/peps/pep-0257/). R code is
+ [documented using `roxygen2` comments](https://cran.r-project.org/web/packages/roxygen2/vignettes/roxygen2.html).
 - Human-readable (preferably HTML) documentation is generated automatically from code documentation.
-- Documentation is hosted for easy access. [GitHub Pages](https://pages.github.com/) and [Read the Docs](https://readthedocs.org/) provide a free service for hosting documentation publicly.
+- Documentation is hosted for easy access. [GitHub Pages](https://pages.github.com/) and
+ [Read the Docs](https://readthedocs.org/) provide a free service for hosting documentation publicly.
 
 ### Project documentation
 
@@ -59,7 +63,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Code is open-sourced. Any sensitive data are omitted or replaced with dummy data.
 - Committing standards are followed such as appropriate commit summary and message supplied.
 - Commits are tagged at significant stages. This is used to indicate the state of code for specific releases or model versions.
-- Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions), to ensure that each change is integrated into the workflow smoothly.
+- Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions),
+ to ensure that each change is integrated into the workflow smoothly.
 
 ### Configuration
 
@@ -75,11 +80,14 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Published outputs meet [accessibility regulations](https://analysisfunction.civilservice.gov.uk/area_of_work/accessibility/).
 - All data for analysis are stored in an open format, so that specific software is not required to access them.
 - Input data are stored safely and are treated as read-only.
-- Input data are versioned. All changes to the data result in new versions being created, or [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
+- Input data are versioned. All changes to the data result in new versions being created,
+ or [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
 - All input data is documented in a data register, including where they come from and their importance to the analysis.
-- Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops. Your analysis code is able to reproduce them at any time.
+- Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops.
+ Your analysis code is able to reproduce them at any time.
 - Non-sensitive data are made available to users. If data are sensitive, dummy data is made available so that the code can be run by others.
-- Data quality is monitored, as per [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+- Data quality is monitored, as per
+ [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
 - Fields within input and output datasets are documented in a data dictionary.
 - Large or complex data are stored in a database.
 - Data are documented in an information asset register.
@@ -99,7 +107,7 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Stakeholder or user acceptance sign-offs are recorded near to the code.
 - Test are automatically run and recorded using continuous integration or git hooks.
 - The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- Test code is clean an readable. Tests make use of fixtures and parametrisation to reduce repetition.
+- Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
 - Formal user acceptance testing is conducted and recorded.
 - Integration tests ensure that multiple units of code work together as expected.
 
@@ -112,7 +120,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Where appropriate, code runs independent of operating system (e.g. suitable management of file paths).
 - Dependencies are managed separately for users, developers, and testers.
 - There are as few dependencies as possible.
-- Package dependencies are managed using an environment manager such as [virtualenv for Python](https://virtualenv.pypa.io/en/latest/) or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
+- Package dependencies are managed using an environment manager such as
+ [virtualenv for Python](https://virtualenv.pypa.io/en/latest/) or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
 - Docker containers or virtual machine builds are available for the code execution environment and these are version controlled.
 
 ### Logging
@@ -128,7 +137,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - New issues or tasks are guided by users’ needs and stories.
 - Issues templates are used to ensure proper logging of the title, description, labels and comments.
 - Acceptance criteria are noted for issues and tasks. Fulfilment of acceptance criteria is recorded.
-- Quality assurance standards and processes for the project are defined. These are based around [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
+- Quality assurance standards and processes for the project are defined. These are based around
+ [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
 
 ## Template checklist
 
@@ -137,7 +147,8 @@ You can either refer to the checklist above, or use the Markdown template below 
 ```{code-block} md
 ## Quality assurance checklist
 
-Quality assurance checklist from [the quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
+Quality assurance checklist from 
+[the quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
 
 ### Modular code
 
@@ -147,14 +158,16 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Low level functions and classes carry out one specific task. As such, there is only one reason to change each function.
 - [ ] Repetition in the code is minimalised. For example, by moving reusable code into functions or classes.
 - [ ] Objects and functions are open for extension but closed for modification; functionality can be extended without modifying the source code.
-- [ ] Subclasses retain the functionality of their parent class while adding new functionality. Parent class objects can be replaced with instances of the subclass and still work as expected.
+- [ ] Subclasses retain the functionality of their parent class while adding new functionality. Parent class objects can be replaced with instances of the
+ subclass and still work as expected.
 
 ### Good coding practices
 
 - [ ] Names used in the code are informative and concise.
 - [ ] Names used in the code are explicit, rather than implicit.
 - [ ] Code logic is clear and avoids unnecessary complexity.
-- [ ] Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/) and [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
+- [ ] Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/) and 
+[Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
 
 ### Project structure
 
@@ -167,9 +180,11 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Comments are kept up to date, so they do not confuse the reader.
 - [ ] Code is not commented out to adjust which lines of code run.
 - [ ] All functions and classes are documented to describe what they do, what inputs they take and what they return.
-- [ ] Python code is [documented using docstrings](https://www.python.org/dev/peps/pep-0257/). R code is [documented using `roxygen2` comments](https://cran.r-project.org/web/packages/roxygen2/vignettes/roxygen2.html).
+- [ ] Python code is [documented using docstrings](https://www.python.org/dev/peps/pep-0257/).
+  R code is [documented using `roxygen2` comments](https://cran.r-project.org/web/packages/roxygen2/vignettes/roxygen2.html).
 - [ ] Human-readable (preferably HTML) documentation is generated automatically from code documentation.
-- [ ] Documentation is hosted for easy access. [GitHub Pages](https://pages.github.com/) and [Read the Docs](https://readthedocs.org/) provide a free service for hosting documentation publicly.
+- [ ] Documentation is hosted for easy access. [GitHub Pages](https://pages.github.com/) and
+ [Read the Docs](https://readthedocs.org/) provide a free service for hosting documentation publicly.
 
 ### Project documentation
 
@@ -180,8 +195,10 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Assumptions in the analysis and their quality are documented next to the code that implements them. These are also made available to users.
 - [ ] Copyright and licenses are specified for both documentation and code.
 - [ ] Instructions for how to cite the project are given.
-- [ ] Releases of the project used for reports, publications, or other outputs are versioned using a standard pattern such as [semantic versioning](https://semver.org/).
-- [ ] A summary of [changes to functionality are documented in a changelog](https://keepachangelog.com/en/1.0.0/) following releases. The changelog is available to users.
+- [ ] Releases of the project used for reports, publications, or other outputs are versioned using a standard pattern such as
+ [semantic versioning](https://semver.org/).
+- [ ] A summary of [changes to functionality are documented in a changelog](https://keepachangelog.com/en/1.0.0/) following releases.
+ The changelog is available to users.
 - [ ] Example usage of packages and underlying functionality is documented for developers and users.
 - [ ] Design certificates confirm that the design is compliant with requirements.
 - [ ] If appropriate, the software is fully specified.
@@ -194,7 +211,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Code is open-sourced. Any sensitive data are omitted or replaced with dummy data.
 - [ ] Committing standards are followed such as appropriate commit summary and message supplied.
 - [ ] Commits are tagged at significant stages. This is used to indicate the state of code for specific releases or model versions.
-- [ ] Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions), to ensure that each change is integrated into the workflow smoothly.
+- [ ] Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions),
+ to ensure that each change is integrated into the workflow smoothly.
 
 ### Configuration
 
@@ -210,11 +228,14 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Published outputs meet [accessibility regulations](https://analysisfunction.civilservice.gov.uk/area_of_work/accessibility/).
 - [ ] All data for analysis are stored in an open format, so that specific software is not required to access them.
 - [ ] Input data are stored safely and are treated as read-only.
-- [ ] Input data are versioned. All changes to the data result in new versions being created, or [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
+- [ ] Input data are versioned. All changes to the data result in new versions being created,
+ or [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
 - [ ] All input data is documented in a data register, including where they come from and their importance to the analysis.
-- [ ] Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops. Your analysis code is able to reproduce them at any time.
+- [ ] Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops.
+ Your analysis code is able to reproduce them at any time.
 - [ ] Non-sensitive data are made available to users. If data are sensitive, dummy data is made available so that the code can be run by others.
-- [ ] Data quality is monitored, as per [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+- [ ] Data quality is monitored, as per
+ [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
 - [ ] Fields within input and output datasets are documented in a data dictionary.
 - [ ] Large or complex data are stored in a database.
 - [ ] Data are documented in an information asset register.
@@ -227,14 +248,15 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 
 ### Testing
 
-- [ ] Core functionality is unit tested as code. See [`pytest` for Python](https://docs.pytest.org/en/stable/) and [`testthat` for R](https://testthat.r-lib.org/). 
+- [ ] Core functionality is unit tested as code. See [`pytest` for Python](https://docs.pytest.org/en/stable/) and
+ [`testthat` for R](https://testthat.r-lib.org/). 
 - [ ] Code based tests are run regularly.
 - [ ] Bug fixes include implementing new unit tests to ensure that the same bug does not reoccur.
 - [ ] Informal tests are recorded near to the code.
 - [ ] Stakeholder or user acceptance sign-offs are recorded near to the code.
 - [ ] Test are automatically run and recorded using continuous integration or git hooks.
 - [ ] The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- [ ] Test code is clean an readable. Tests make use of fixtures and parametrisation to reduce repetition.
+- [ ] Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
 - [ ] Formal user acceptance testing is conducted and recorded.
 - [ ] Integration tests ensure that multiple units of code work together as expected.
 
@@ -247,7 +269,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Where appropriate, code runs independent of operating system (e.g. suitable management of file paths).
 - [ ] Dependencies are managed separately for users, developers, and testers.
 - [ ] There are as few dependencies as possible.
-- [ ] Package dependencies are managed using an environment manager such as [virtualenv for Python](https://virtualenv.pypa.io/en/latest/) or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
+- [ ] Package dependencies are managed using an environment manager such as
+ [virtualenv for Python](https://virtualenv.pypa.io/en/latest/) or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
 - [ ] Docker containers or virtual machine builds are available for the code execution environment and these are version controlled.
 
 ### Logging
@@ -263,5 +286,6 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] New issues or tasks are guided by users’ needs and stories.
 - [ ] Issues templates are used to ensure proper logging of the title, description, labels and comments.
 - [ ] Acceptance criteria are noted for issues and tasks. Fulfilment of acceptance criteria is recorded.
-- [ ] Quality assurance standards and processes for the project are defined. These are based around [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
+- [ ] Quality assurance standards and processes for the project are defined. These are based around
+ [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
 ```

--- a/book/checklist_moderate.md
+++ b/book/checklist_moderate.md
@@ -96,7 +96,7 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Stakeholder or user acceptance sign-offs are recorded near to the code.
 - Test are automatically run and recorded using continuous integration or git hooks.
 - The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
+- Test code is clean and readable. Tests make use of fixtures and parameterisation to reduce repetition.
 
 ### Dependency management
 

--- a/book/checklist_moderate.md
+++ b/book/checklist_moderate.md
@@ -17,7 +17,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Names used in the code are informative and concise.
 - Names used in the code are explicit, rather than implicit.
 - Code logic is clear and avoids unnecessary complexity.
-- Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/) and [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
+- Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/) and
+ [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
 
 ### Project structure
 
@@ -54,7 +55,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Code is open-sourced. Any sensitive data are omitted or replaced with dummy data.
 - Committing standards are followed such as appropriate commit summary and message supplied.
 - Commits are tagged at significant stages. This is used to indicate the state of code for specific releases or model versions.
-- Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions), to ensure that each change is integrated into the workflow smoothly.
+- Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions),
+ to ensure that each change is integrated into the workflow smoothly.
 
 ### Configuration
 
@@ -71,9 +73,11 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Input data are stored safely and are treated as read-only.
 - Input data are versioned. All changes to the data result in new versions being created, or [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
 - All input data is documented in a data register, including where they come from and their importance to the analysis.
-- Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops. Your analysis code is able to reproduce them at any time.
+- Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops.
+ Your analysis code is able to reproduce them at any time.
 - Non-sensitive data are made available to users. If data are sensitive, dummy data is made available so that the code can be run by others.
-- Data quality is monitored, as per [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+- Data quality is monitored, as per
+ [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
 - Fields within input and output datasets are documented in a data dictionary.
 - Large or complex data are stored in a database.
 
@@ -92,7 +96,7 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Stakeholder or user acceptance sign-offs are recorded near to the code.
 - Test are automatically run and recorded using continuous integration or git hooks.
 - The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- Test code is clean an readable. Tests make use of fixtures and parametrisation to reduce repetition.
+- Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
 
 ### Dependency management
 
@@ -103,7 +107,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - Where appropriate, code runs independent of operating system (e.g. suitable management of file paths).
 - Dependencies are managed separately for users, developers, and testers.
 - There are as few dependencies as possible.
-- Package dependencies are managed using an environment manager such as [virtualenv for Python](https://virtualenv.pypa.io/en/latest/) or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
+- Package dependencies are managed using an environment manager such as [virtualenv for Python](https://virtualenv.pypa.io/en/latest/)
+ or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
 
 ### Logging
 
@@ -118,7 +123,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - New issues or tasks are guided by users’ needs and stories.
 - Issues templates are used to ensure proper logging of the title, description, labels and comments.
 - Acceptance criteria are noted for issues and tasks. Fulfilment of acceptance criteria is recorded.
-- Quality assurance standards and processes for the project are defined. These are based around [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
+- Quality assurance standards and processes for the project are defined. These are based around
+ [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
 
 ## Template checklist
 
@@ -127,7 +133,8 @@ You can either refer to the checklist above, or use the Markdown template below 
 ```{code-block} md
 ## Quality assurance checklist
 
-Quality assurance checklist from [the quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
+Quality assurance checklist from
+ [the quality assurance of code for analysis and research guidance](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
 
 ### Modular code
 
@@ -142,7 +149,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Names used in the code are informative and concise.
 - [ ] Names used in the code are explicit, rather than implicit.
 - [ ] Code logic is clear and avoids unnecessary complexity.
-- [ ] Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/) and [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
+- [ ] Code follows a standard style, e.g. [PEP8 for Python](https://www.python.org/dev/peps/pep-0008/)
+ and [Google](https://google.github.io/styleguide/Rguide.html) or [tidyverse](https://style.tidyverse.org/) for R.
 
 ### Project structure
 
@@ -155,7 +163,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Comments are kept up to date, so they do not confuse the reader.
 - [ ] Code is not commented out to adjust which lines of code run.
 - [ ] All functions and classes are documented to describe what they do, what inputs they take and what they return.
-- [ ] Python code is [documented using docstrings](https://www.python.org/dev/peps/pep-0257/). R code is [documented using `roxygen2` comments](https://cran.r-project.org/web/packages/roxygen2/vignettes/roxygen2.html).
+- [ ] Python code is [documented using docstrings](https://www.python.org/dev/peps/pep-0257/).
+ R code is [documented using `roxygen2` comments](https://cran.r-project.org/web/packages/roxygen2/vignettes/roxygen2.html).
 - [ ] Human-readable (preferably HTML) documentation is generated automatically from code documentation.
 
 ### Project documentation
@@ -167,8 +176,10 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Assumptions in the analysis and their quality are documented next to the code that implements them. These are also made available to users.
 - [ ] Copyright and licenses are specified for both documentation and code.
 - [ ] Instructions for how to cite the project are given.
-- [ ] Releases of the project used for reports, publications, or other outputs are versioned using a standard pattern such as [semantic versioning](https://semver.org/).
-- [ ] A summary of [changes to functionality are documented in a changelog](https://keepachangelog.com/en/1.0.0/) following releases. The changelog is available to users.
+- [ ] Releases of the project used for reports, publications, or other outputs are versioned using a standard pattern such as
+ [semantic versioning](https://semver.org/).
+- [ ] A summary of [changes to functionality are documented in a changelog](https://keepachangelog.com/en/1.0.0/) following releases.
+ The changelog is available to users.
 - [ ] Example usage of packages and underlying functionality is documented for developers and users.
 
 ### Version control
@@ -179,7 +190,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Code is open-sourced. Any sensitive data are omitted or replaced with dummy data.
 - [ ] Committing standards are followed such as appropriate commit summary and message supplied.
 - [ ] Commits are tagged at significant stages. This is used to indicate the state of code for specific releases or model versions.
-- [ ] Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions), to ensure that each change is integrated into the workflow smoothly.
+- [ ] Continuous integration is applied through tools such as [GitHub Actions](https://github.com/features/actions),
+ to ensure that each change is integrated into the workflow smoothly.
 
 ### Configuration
 
@@ -194,11 +206,14 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Published outputs meet [accessibility regulations](https://analysisfunction.civilservice.gov.uk/area_of_work/accessibility/).
 - [ ] All data for analysis are stored in an open format, so that specific software is not required to access them.
 - [ ] Input data are stored safely and are treated as read-only.
-- [ ] Input data are versioned. All changes to the data result in new versions being created, or [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
+- [ ] Input data are versioned. All changes to the data result in new versions being created, or
+ [changes are recorded as new records](https://en.wikipedia.org/wiki/Slowly_changing_dimension).
 - [ ] All input data is documented in a data register, including where they come from and their importance to the analysis.
-- [ ] Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops. Your analysis code is able to reproduce them at any time.
+- [ ] Outputs from your analysis are disposable and are regularly deleted and regenerated while analysis develops.
+ Your analysis code is able to reproduce them at any time.
 - [ ] Non-sensitive data are made available to users. If data are sensitive, dummy data is made available so that the code can be run by others.
-- [ ] Data quality is monitored, as per [the government data quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
+- [ ] Data quality is monitored, as per [the government data
+ quality framework](https://www.gov.uk/government/publications/the-government-data-quality-framework/the-government-data-quality-framework).
 - [ ] Fields within input and output datasets are documented in a data dictionary.
 - [ ] Large or complex data are stored in a database.
 
@@ -210,14 +225,15 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 
 ### Testing
 
-- [ ] Core functionality is unit tested as code. See [`pytest` for Python](https://docs.pytest.org/en/stable/) and [`testthat` for R](https://testthat.r-lib.org/). 
+- [ ] Core functionality is unit tested as code. See [`pytest` for Python](https://docs.pytest.org/en/stable/) and
+ [`testthat` for R](https://testthat.r-lib.org/). 
 - [ ] Code based tests are run regularly.
 - [ ] Bug fixes include implementing new unit tests to ensure that the same bug does not reoccur.
 - [ ] Informal tests are recorded near to the code.
 - [ ] Stakeholder or user acceptance sign-offs are recorded near to the code.
 - [ ] Test are automatically run and recorded using continuous integration or git hooks.
 - [ ] The whole process is tested from start to finish using one or more realistic end-to-end tests.
-- [ ] Test code is clean an readable. Tests make use of fixtures and parametrisation to reduce repetition.
+- [ ] Test code is clean an readable. Tests make use of fixtures and parameterisation to reduce repetition.
 
 ### Dependency management
 
@@ -228,7 +244,8 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] Where appropriate, code runs independent of operating system (e.g. suitable management of file paths).
 - [ ] Dependencies are managed separately for users, developers, and testers.
 - [ ] There are as few dependencies as possible.
-- [ ] Package dependencies are managed using an environment manager such as [virtualenv for Python](https://virtualenv.pypa.io/en/latest/) or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
+- [ ] Package dependencies are managed using an environment manager such as [virtualenv for Python](https://virtualenv.pypa.io/en/latest/)
+ or [renv for R](https://rstudio.github.io/renv/articles/renv.html).
 
 ### Logging
 
@@ -243,5 +260,6 @@ Quality assurance checklist from [the quality assurance of code for analysis and
 - [ ] New issues or tasks are guided by users’ needs and stories.
 - [ ] Issues templates are used to ensure proper logging of the title, description, labels and comments.
 - [ ] Acceptance criteria are noted for issues and tasks. Fulfilment of acceptance criteria is recorded.
-- [ ] Quality assurance standards and processes for the project are defined. These are based around [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
+- [ ] Quality assurance standards and processes for the project are defined. These are based around
+ [the quality assurance of code for analysis and research guidance document](https://best-practice-and-impact.github.io/qa-of-code-guidance/intro.html).
 ```

--- a/book/testing_code.md
+++ b/book/testing_code.md
@@ -274,7 +274,8 @@ but you should ensure that good modular code practices are followed to separate 
 
 When we implement new logic in code, tests are required to assure us that the code works as expected.
 
-To make sure that your code works as expected, you should write tests for each individual unit in your code. A unit is the smallest modular piece of logic in the code - a function or method.
+To make sure that your code works as expected, you should write tests for each individual unit in your code.
+A unit is the smallest modular piece of logic in the code - a function or method.
 
 Unit tests should cover realistic use cases for your function, such as:
 * boundary cases, like the highest and lowest expected input values
@@ -345,7 +346,8 @@ This might be from a user need (e.g. someone needs output data in a certain shap
 Given that you know the expected outcome, you can write the test before even thinking about how you are going to write the solution.
 
 ```{note}
-This section is framed more like training. Once dedicated training has been produced this section will likely be adapted to provide more concise guidance on the practice.
+This section is framed more like training. Once dedicated training has been produced this section will likely be adapted to provide more concise guidance on
+the practice.
 ```
 
 TDD typically repeats three steps:
@@ -371,7 +373,7 @@ TDD requires practice but is proven to produce clean, robust and adaptable code.
 [acceptance test driven development](https://en.wikipedia.org/wiki/Acceptance_test-driven_development)
 are extensions of TDD with a useful focus on user needs.
 
-## Reduce repetition in test code (fixtures and parametrized tests)
+## Reduce repetition in test code (fixtures and parameterised tests)
 
 Where possible, reduce repetition in your tests. Tests are code too, so you should still [make this code reusable](functions).
 As with functional code, test code is much easier to maintain when it is modular and reusable.
@@ -443,13 +445,13 @@ For usage details see the documentation for packages that offer fixtures:
 * [Python `pytest` Fixture](https://docs.pytest.org/en/stable/fixture.html) documentation
 * [R `testthat` Fixture](https://testthat.r-lib.org/articles/test-fixtures.html) documentation
 
-### Use parametrization to reduce repetition in test logic
+### Use parameterisation to reduce repetition in test logic
 
 Similar steps are often repeated when testing multiple combinations of inputs and outputs.
-Parametrization allows us to reduce repetition in our test code, in a similar way to writing our logic in functions.
+Parameterisation allows us to reduce repetition in our test code, in a similar way to writing our logic in functions.
 You should specify pairs of inputs and expected outputs, so that your testing tool can repeat the same test for each scenario.
 
-Using parametrization in a test framework is equivalent to using a for-loop to apply a test function over multiple inputs and expected outputs.
+Using parameterisation in a test framework is equivalent to using a for-loop to apply a test function over multiple inputs and expected outputs.
 Using functionality from test packages may provide improved running efficiency and more detailed reporting of test failures.
 
 In `pytest`, this can be achieved using the [Parametrize mark](https://docs.pytest.org/en/stable/parametrize.html).
@@ -459,7 +461,7 @@ In R, the `patrick` package extends `testthat` to provide a
 
 ### Define Source Code
 
-Take the below function for example, it can take 2 arguments. 
+Take the below function for example, it can take 2 arguments.
 
 ```{code-block} python
 def sum_two_nums(num1:int, num2:int) -> int:
@@ -467,42 +469,42 @@ def sum_two_nums(num1:int, num2:int) -> int:
     return num1 + num2
 ```
 
-### Simple Parametrization
+### Simple Parameterisation
 
 It is simple to check multiple assertions for this simple function. In the most
-basic example, simply define a parametrized list of parameter values and
+basic example, simply define a parameterised list of parameter values and
 expected outcomes.
 
 ```{code-block} python
 import pytest
 
 @pytest.mark.parametrize("num_1s, expected_out", [(1, 2), (-1, 0), (0, 1)])
-def test_sum_two_nums_parametrize_arg_1(num_1s, expected_out):
+def test_sum_two_nums_parameterise_arg_1(num_1s, expected_out):
     assert sum_two_nums(num1=num_1s, num2=1) == expected_out
 
 ```
 
 We reference the parameter values and expected answers in the same way that we
 access pytest fixtures, covered earlier in this article. Running `pytest -v`
-reveals 3 tests are run, with the parametrized values printed to the console:
+reveals 3 tests are run, with the parameterised values printed to the console:
 
 ```{code-block}
 
 collected 3 items                                                             
 
-foo.py::test_sum_two_nums_parametrize_arg_1[1-2] PASSED                  [ 33%]
-foo.py::test_sum_two_nums_parametrize_arg_1[-1-0] PASSED                 [ 66%]
-foo.py::test_sum_two_nums_parametrize_arg_1[0-1] PASSED                  [100%]
+foo.py::test_sum_two_nums_parameterise_arg_1[1-2] PASSED                  [ 33%]
+foo.py::test_sum_two_nums_parameterise_arg_1[-1-0] PASSED                 [ 66%]
+foo.py::test_sum_two_nums_parameterise_arg_1[0-1] PASSED                  [100%]
 
 ============================= 3 passed in 0.00s ==============================
 
 ```
 
-It would be trivial to repeat a similar parametrized test for `num_2` values.
-But how is it possible to make assertions when parametrizing **both**
+It would be trivial to repeat a similar parameterised test for `num_2` values.
+But how is it possible to make assertions when parameterising **both**
 arguments?
 
-### Stacked Parametrization
+### Stacked Parameterisation
 
 In order to test multiple values for `num1` and `num2`, a fixture should be
 defined that returns a dictionary of the expected values. For example:
@@ -515,7 +517,7 @@ def expected_answers() -> dict:
 
     First level key corresponds to `num1` and the second level key to `num2`.
     The dictionary values are the expected answers. So that when we subset the
-    dictionary with parametrized values, we provide the expected values to
+    dictionary with parameterised values, we provide the expected values to
     assert statements.
 
     Returns
@@ -534,16 +536,16 @@ def expected_answers() -> dict:
 
 ```
 
-This fixture of expected answers can be served to a parametrized test and the
+This fixture of expected answers can be served to a parameterised test and the
 returned dictionary can be accessed to provide the expected answer for
-parameter combinations. In order to parametrize both of the required arguments,
-the parametrize statements are simply stacked on top of each other:
+parameter combinations. In order to parameterise both of the required arguments,
+the parameterise statements are simply stacked on top of each other:
 
 ```{code-block} python
 
 @pytest.mark.parametrize("num1s", range(0,5))
 @pytest.mark.parametrize("num2s", range(0,5))
-def test_sum_two_nums_stacked_parametrize(num1s, num2s, expected_answers):
+def test_sum_two_nums_stacked_parameterise(num1s, num2s, expected_answers):
     assert sum_two_nums(
         num1=num1s, num2=num2s
         ) == expected_answers[num1s][num2s]
@@ -554,31 +556,31 @@ Executing this test with `pytest -v` shows all combinations are tested:
 ```{code-block}
 collected 25 items                                                            
 
-foo.py::test_sum_two_nums_stacked_parametrize[0-0] PASSED                [ 14%]
-foo.py::test_sum_two_nums_stacked_parametrize[0-1] PASSED                [ 17%]
-foo.py::test_sum_two_nums_stacked_parametrize[0-2] PASSED                [ 21%]
-foo.py::test_sum_two_nums_stacked_parametrize[0-3] PASSED                [ 25%]
-foo.py::test_sum_two_nums_stacked_parametrize[0-4] PASSED                [ 28%]
-foo.py::test_sum_two_nums_stacked_parametrize[1-0] PASSED                [ 32%]
-foo.py::test_sum_two_nums_stacked_parametrize[1-1] PASSED                [ 35%]
-foo.py::test_sum_two_nums_stacked_parametrize[1-2] PASSED                [ 39%]
-foo.py::test_sum_two_nums_stacked_parametrize[1-3] PASSED                [ 42%]
-foo.py::test_sum_two_nums_stacked_parametrize[1-4] PASSED                [ 46%]
-foo.py::test_sum_two_nums_stacked_parametrize[2-0] PASSED                [ 50%]
-foo.py::test_sum_two_nums_stacked_parametrize[2-1] PASSED                [ 53%]
-foo.py::test_sum_two_nums_stacked_parametrize[2-2] PASSED                [ 57%]
-foo.py::test_sum_two_nums_stacked_parametrize[2-3] PASSED                [ 60%]
-foo.py::test_sum_two_nums_stacked_parametrize[2-4] PASSED                [ 64%]
-foo.py::test_sum_two_nums_stacked_parametrize[3-0] PASSED                [ 67%]
-foo.py::test_sum_two_nums_stacked_parametrize[3-1] PASSED                [ 71%]
-foo.py::test_sum_two_nums_stacked_parametrize[3-2] PASSED                [ 75%]
-foo.py::test_sum_two_nums_stacked_parametrize[3-3] PASSED                [ 78%]
-foo.py::test_sum_two_nums_stacked_parametrize[3-4] PASSED                [ 82%]
-foo.py::test_sum_two_nums_stacked_parametrize[4-0] PASSED                [ 85%]
-foo.py::test_sum_two_nums_stacked_parametrize[4-1] PASSED                [ 89%]
-foo.py::test_sum_two_nums_stacked_parametrize[4-2] PASSED                [ 92%]
-foo.py::test_sum_two_nums_stacked_parametrize[4-3] PASSED                [ 96%]
-foo.py::test_sum_two_nums_stacked_parametrize[4-4] PASSED                [100%]
+foo.py::test_sum_two_nums_stacked_parameterise[0-0] PASSED                [ 14%]
+foo.py::test_sum_two_nums_stacked_parameterise[0-1] PASSED                [ 17%]
+foo.py::test_sum_two_nums_stacked_parameterise[0-2] PASSED                [ 21%]
+foo.py::test_sum_two_nums_stacked_parameterise[0-3] PASSED                [ 25%]
+foo.py::test_sum_two_nums_stacked_parameterise[0-4] PASSED                [ 28%]
+foo.py::test_sum_two_nums_stacked_parameterise[1-0] PASSED                [ 32%]
+foo.py::test_sum_two_nums_stacked_parameterise[1-1] PASSED                [ 35%]
+foo.py::test_sum_two_nums_stacked_parameterise[1-2] PASSED                [ 39%]
+foo.py::test_sum_two_nums_stacked_parameterise[1-3] PASSED                [ 42%]
+foo.py::test_sum_two_nums_stacked_parameterise[1-4] PASSED                [ 46%]
+foo.py::test_sum_two_nums_stacked_parameterise[2-0] PASSED                [ 50%]
+foo.py::test_sum_two_nums_stacked_parameterise[2-1] PASSED                [ 53%]
+foo.py::test_sum_two_nums_stacked_parameterise[2-2] PASSED                [ 57%]
+foo.py::test_sum_two_nums_stacked_parameterise[2-3] PASSED                [ 60%]
+foo.py::test_sum_two_nums_stacked_parameterise[2-4] PASSED                [ 64%]
+foo.py::test_sum_two_nums_stacked_parameterise[3-0] PASSED                [ 67%]
+foo.py::test_sum_two_nums_stacked_parameterise[3-1] PASSED                [ 71%]
+foo.py::test_sum_two_nums_stacked_parameterise[3-2] PASSED                [ 75%]
+foo.py::test_sum_two_nums_stacked_parameterise[3-3] PASSED                [ 78%]
+foo.py::test_sum_two_nums_stacked_parameterise[3-4] PASSED                [ 82%]
+foo.py::test_sum_two_nums_stacked_parameterise[4-0] PASSED                [ 85%]
+foo.py::test_sum_two_nums_stacked_parameterise[4-1] PASSED                [ 89%]
+foo.py::test_sum_two_nums_stacked_parameterise[4-2] PASSED                [ 92%]
+foo.py::test_sum_two_nums_stacked_parameterise[4-3] PASSED                [ 96%]
+foo.py::test_sum_two_nums_stacked_parameterise[4-4] PASSED                [100%]
 
 ============================= 25 passed in 0.01s =============================
 


### PR DESCRIPTION
Changed all spellings to parameterise/parameterised/parameterisation across the book to ensure consistency within the book, but also with other published works on gov.uk. The only exception is where we have referred to pytest.mark.parametrize, as this is a decorator and we can't change it!

Also had to fiddle with the line length for some of the chapters as the pre-commit hooks were failing. Have rendered the pages locally and they still look fine, but it's worth double checking I haven't borked something else in doing so.