### PR TITLE
Update config to work with auto generated header anchors

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -26,6 +26,7 @@ sphinx:
     todo_include_todos: true
     language: en
     html_show_copyright: false
+    myst_heading_anchors: 3
 
 latex:
   latex_documents:


### PR DESCRIPTION
Workflow, specifically myst-parser, now fails when linking to headers within the book. See issue discussing the problem [here
](https://github.com/executablebooks/MyST-Parser/issues/519/). This is expected behaviour, so I've updated the config as recommended [here](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#auto-generated-header-anchors).

I've set the depth to 3 for now in case we want to link to headings that deep in the future. Workflow now passes.
