### PR TITLE
Fix command-line arguments R example

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -248,7 +248,7 @@ with open(config_path) as file:
 ```
 
 ```{code-tab} r R
-args <- commandArgs()
+args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 1) {
   stop("Configuration file must be passed as an argument.")
 }


### PR DESCRIPTION
`commandArgs()` by default returns the name of the executable and the name of the file as the first two items. Using `trailingOnly = TRUE` fixes this.